### PR TITLE
:sparkles: feat: GitHub Action 자동 Release 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haya14busa/action-bumpr@v1


### PR DESCRIPTION
## 🛰️ Issue Number
- #7 

## 🪐 작업 내용
label과 함께 main 브랜치에 push 된 merge commit에 대해 자동으로 release 하도록 하는 GitHub Action workflow 추가

## 📚 Reference
[Bumpr](https://github.com/marketplace/actions/bumpr-bump-version-when-merging-pull-request-with-specific-labels)
[Tested PR](https://github.com/dlsrks1021/kopring_lintertest/pull/2)
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge 할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?