### PR TITLE
[feat] 게임 방 전체 목록 조회 api 구현

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/api/RoomController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/api/RoomController.java
@@ -3,12 +3,10 @@ package io.f1.backend.domain.game.api;
 import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.request.RoomCreateRequest;
 import io.f1.backend.domain.game.dto.response.RoomCreateResponse;
-
 import io.f1.backend.domain.game.dto.response.RoomListResponse;
-import io.f1.backend.domain.game.model.Room;
+
 import jakarta.validation.Valid;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/io/f1/backend/domain/game/api/RoomController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/api/RoomController.java
@@ -4,11 +4,15 @@ import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.request.RoomCreateRequest;
 import io.f1.backend.domain.game.dto.response.RoomCreateResponse;
 
+import io.f1.backend.domain.game.dto.response.RoomListResponse;
+import io.f1.backend.domain.game.model.Room;
 import jakarta.validation.Valid;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +38,10 @@ public class RoomController {
         loginUser.put("nickname", "빵야빵야");
 
         return roomService.saveRoom(request, loginUser);
+    }
+
+    @GetMapping
+    public RoomListResponse getAllRooms() {
+        return roomService.getAllRooms();
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -2,9 +2,9 @@ package io.f1.backend.domain.game.app;
 
 import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSetting;
 
-import io.f1.backend.domain.game.dto.response.RoomListResponse;
 import io.f1.backend.domain.game.dto.request.RoomCreateRequest;
 import io.f1.backend.domain.game.dto.response.RoomCreateResponse;
+import io.f1.backend.domain.game.dto.response.RoomListResponse;
 import io.f1.backend.domain.game.dto.response.RoomResponse;
 import io.f1.backend.domain.game.mapper.RoomMapper;
 import io.f1.backend.domain.game.model.GameSetting;
@@ -12,14 +12,14 @@ import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomSetting;
 import io.f1.backend.domain.game.store.RoomRepository;
-
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.entity.User;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,20 +48,23 @@ public class RoomService {
     // todo quizService에서 퀴즈 조회 메서드로 변경
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
-        List<RoomResponse> roomResponses = rooms.stream().map(room -> {
+        List<RoomResponse> roomResponses =
+                rooms.stream()
+                        .map(
+                                room -> {
+                                    User user = new User(); // 임시 유저 객체
+                                    user.setNickname("임시 유저 닉네임");
 
-            User user = new User(); // 임시 유저 객체
-            user.setNickname("임시 유저 닉네임");
+                                    Quiz quiz = new Quiz(); // 임시 퀴즈 객체
+                                    quiz.setTitle("임시 퀴즈 제목");
+                                    quiz.setDescription("임시 퀴즈 설명");
+                                    quiz.setThumbnailUrl("임시 이미지");
+                                    quiz.setQuestions(List.of());
+                                    quiz.setCreator(user);
 
-            Quiz quiz = new Quiz(); // 임시 퀴즈 객체
-            quiz.setTitle("임시 퀴즈 제목");
-            quiz.setDescription("임시 퀴즈 설명");
-            quiz.setThumbnailUrl("임시 이미지");
-            quiz.setQuestions(List.of());
-            quiz.setCreator(user);
-
-            return RoomMapper.toRoomResponse(room, quiz);
-        }).toList();
+                                    return RoomMapper.toRoomResponse(room, quiz);
+                                })
+                        .toList();
         return new RoomListResponse(roomResponses);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -2,14 +2,20 @@ package io.f1.backend.domain.game.app;
 
 import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSetting;
 
+import io.f1.backend.domain.game.dto.response.RoomListResponse;
 import io.f1.backend.domain.game.dto.request.RoomCreateRequest;
 import io.f1.backend.domain.game.dto.response.RoomCreateResponse;
+import io.f1.backend.domain.game.dto.response.RoomResponse;
+import io.f1.backend.domain.game.mapper.RoomMapper;
 import io.f1.backend.domain.game.model.GameSetting;
 import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomSetting;
 import io.f1.backend.domain.game.store.RoomRepository;
 
+import io.f1.backend.domain.quiz.entity.Quiz;
+import io.f1.backend.domain.user.entity.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -37,5 +43,25 @@ public class RoomService {
         roomRepository.saveRoom(new Room(newId, roomSetting, gameSetting, host));
 
         return new RoomCreateResponse(newId);
+    }
+
+    // todo quizService에서 퀴즈 조회 메서드로 변경
+    public RoomListResponse getAllRooms() {
+        List<Room> rooms = roomRepository.findAll();
+        List<RoomResponse> roomResponses = rooms.stream().map(room -> {
+
+            User user = new User(); // 임시 유저 객체
+            user.setNickname("임시 유저 닉네임");
+
+            Quiz quiz = new Quiz(); // 임시 퀴즈 객체
+            quiz.setTitle("임시 퀴즈 제목");
+            quiz.setDescription("임시 퀴즈 설명");
+            quiz.setThumbnailUrl("임시 이미지");
+            quiz.setQuestions(List.of());
+            quiz.setCreator(user);
+
+            return RoomMapper.toRoomResponse(room, quiz);
+        }).toList();
+        return new RoomListResponse(roomResponses);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomListResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomListResponse.java
@@ -1,0 +1,9 @@
+package io.f1.backend.domain.game.dto.response;
+
+import java.util.List;
+
+public record RoomListResponse(
+    List<RoomResponse> rooms
+) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomListResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomListResponse.java
@@ -2,8 +2,4 @@ package io.f1.backend.domain.game.dto.response;
 
 import java.util.List;
 
-public record RoomListResponse(
-    List<RoomResponse> rooms
-) {
-
-}
+public record RoomListResponse(List<RoomResponse> rooms) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomResponse.java
@@ -1,17 +1,14 @@
 package io.f1.backend.domain.game.dto.response;
 
 public record RoomResponse(
-    Long roomId,
-    String title,
-    int maxUserCount,
-    int currentUserCount,
-    boolean locked,
-    String roomState,
-    String quizTitle,
-    String description,
-    String creator,
-    int numberOfQuestions,
-    String thumbnailUrl
-) {
-
-}
+        Long roomId,
+        String title,
+        int maxUserCount,
+        int currentUserCount,
+        boolean locked,
+        String roomState,
+        String quizTitle,
+        String description,
+        String creator,
+        int numberOfQuestions,
+        String thumbnailUrl) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/RoomResponse.java
@@ -1,0 +1,17 @@
+package io.f1.backend.domain.game.dto.response;
+
+public record RoomResponse(
+    Long roomId,
+    String title,
+    int maxUserCount,
+    int currentUserCount,
+    boolean locked,
+    String roomState,
+    String quizTitle,
+    String description,
+    String creator,
+    int numberOfQuestions,
+    String thumbnailUrl
+) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
@@ -15,17 +15,16 @@ public class RoomMapper {
 
     public static RoomResponse toRoomResponse(Room room, Quiz quiz) {
         return new RoomResponse(
-            room.getId(),
-            room.getRoomSetting().roomName(),
-            room.getRoomSetting().maxUserCount(),
-            room.getPlayerSessionMap().size(),
-            room.getRoomSetting().locked(),
-            room.getState().name(),
-            quiz.getTitle(),
-            quiz.getDescription(),
-            quiz.getCreator().getNickname(),
-            quiz.getQuestions().size(),
-            quiz.getThumbnailUrl()
-        );
+                room.getId(),
+                room.getRoomSetting().roomName(),
+                room.getRoomSetting().maxUserCount(),
+                room.getPlayerSessionMap().size(),
+                room.getRoomSetting().locked(),
+                room.getState().name(),
+                quiz.getTitle(),
+                quiz.getDescription(),
+                quiz.getCreator().getNickname(),
+                quiz.getQuestions().size(),
+                quiz.getThumbnailUrl());
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
@@ -1,12 +1,31 @@
 package io.f1.backend.domain.game.mapper;
 
 import io.f1.backend.domain.game.dto.request.RoomCreateRequest;
+import io.f1.backend.domain.game.dto.response.RoomResponse;
+import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomSetting;
+import io.f1.backend.domain.quiz.entity.Quiz;
 
 public class RoomMapper {
 
     public static RoomSetting toRoomSetting(RoomCreateRequest request) {
         return new RoomSetting(
                 request.roomName(), request.maxUserCount(), request.locked(), request.password());
+    }
+
+    public static RoomResponse toRoomResponse(Room room, Quiz quiz) {
+        return new RoomResponse(
+            room.getId(),
+            room.getRoomSetting().roomName(),
+            room.getRoomSetting().maxUserCount(),
+            room.getPlayerSessionMap().size(),
+            room.getRoomSetting().locked(),
+            room.getState().name(),
+            quiz.getTitle(),
+            quiz.getDescription(),
+            quiz.getCreator().getNickname(),
+            quiz.getQuestions().size(),
+            quiz.getThumbnailUrl()
+        );
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
@@ -1,6 +1,7 @@
 package io.f1.backend.domain.game.store;
 
 import io.f1.backend.domain.game.model.Room;
+
 import java.util.List;
 
 public interface RoomRepository {
@@ -8,5 +9,4 @@ public interface RoomRepository {
     void saveRoom(Room room);
 
     List<Room> findAll();
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
@@ -1,7 +1,12 @@
 package io.f1.backend.domain.game.store;
 
 import io.f1.backend.domain.game.model.Room;
+import java.util.List;
 
 public interface RoomRepository {
+
     void saveRoom(Room room);
+
+    List<Room> findAll();
+
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -2,6 +2,8 @@ package io.f1.backend.domain.game.store;
 
 import io.f1.backend.domain.game.model.Room;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
@@ -15,6 +17,11 @@ public class RoomRepositoryImpl implements RoomRepository {
     @Override
     public void saveRoom(Room room) {
         roomMap.put(room.getId(), room);
+    }
+
+    @Override
+    public List<Room> findAll() {
+        return new ArrayList<>(roomMap.values());
     }
 
     // 테스트 전용 메소드

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -2,10 +2,10 @@ package io.f1.backend.domain.game.store;
 
 import io.f1.backend.domain.game.model.Room;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -18,7 +18,11 @@ import jakarta.persistence.OneToMany;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter // quizService의 퀴즈 조회 메서드 구현 시까지 임시 사용
 @Entity
 public class Quiz extends BaseEntity {
 

--- a/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
@@ -13,7 +13,11 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter // quizService의 퀴즈 조회 메서드 구현 시까지 임시 사용
 @Entity
 @Table(name = "`user`")
 public class User extends BaseEntity {

--- a/backend/src/test/java/io/f1/backend/domain/game/store/RoomRepositoryTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/store/RoomRepositoryTests.java
@@ -8,12 +8,12 @@ import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomSetting;
 
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 class RoomRepositoryTests {
@@ -76,8 +76,18 @@ class RoomRepositoryTests {
 
         GameSetting gameSetting = new GameSetting(1L, 10, 60);
 
-        RoomSetting roomSetting1 = new RoomSetting(request1.roomName(), request1.maxUserCount(), request1.locked(), request1.password());
-        RoomSetting roomSetting2 = new RoomSetting(request2.roomName(), request2.maxUserCount(), request2.locked(), request2.password());
+        RoomSetting roomSetting1 =
+                new RoomSetting(
+                        request1.roomName(),
+                        request1.maxUserCount(),
+                        request1.locked(),
+                        request1.password());
+        RoomSetting roomSetting2 =
+                new RoomSetting(
+                        request2.roomName(),
+                        request2.maxUserCount(),
+                        request2.locked(),
+                        request2.password());
 
         Room room1 = new Room(1L, roomSetting1, gameSetting, host1);
         Room room2 = new Room(2L, roomSetting2, gameSetting, host2);
@@ -91,7 +101,8 @@ class RoomRepositoryTests {
         // then: 저장한 방 2개가 모두 조회되어야하고
         assertThat(allRooms).hasSize(2);
         assertThat(allRooms).extracting("id").containsExactlyInAnyOrder(1L, 2L);
-        assertThat(allRooms).extracting(room -> room.getRoomSetting().roomName()).containsExactlyInAnyOrder("방이름_1", "방이름_2");
-
+        assertThat(allRooms)
+                .extracting(room -> room.getRoomSetting().roomName())
+                .containsExactlyInAnyOrder("방이름_1", "방이름_2");
     }
 }

--- a/backend/src/test/java/io/f1/backend/domain/game/store/RoomRepositoryTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/store/RoomRepositoryTests.java
@@ -8,6 +8,7 @@ import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomSetting;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,5 +61,37 @@ class RoomRepositoryTests {
         assertThat(savedRoom.getRoomSetting().maxUserCount()).isEqualTo(request.maxUserCount());
         assertThat(savedRoom.getRoomSetting().locked()).isEqualTo(request.locked());
         assertThat(savedRoom.getRoomSetting().password()).isEqualTo(request.password());
+    }
+
+    @Test
+    @DisplayName("게임 방 전체 조회 테스트")
+    void findAll_test() throws Exception {
+
+        // given: 테스트를 위한 방 2개 생성 및 저장
+        RoomCreateRequest request1 = new RoomCreateRequest("방이름_1", 3, "password1", true);
+        RoomCreateRequest request2 = new RoomCreateRequest("방이름_2", 5, "", false);
+
+        Player host1 = new Player(1L, "방장 1");
+        Player host2 = new Player(2L, "호스트2");
+
+        GameSetting gameSetting = new GameSetting(1L, 10, 60);
+
+        RoomSetting roomSetting1 = new RoomSetting(request1.roomName(), request1.maxUserCount(), request1.locked(), request1.password());
+        RoomSetting roomSetting2 = new RoomSetting(request2.roomName(), request2.maxUserCount(), request2.locked(), request2.password());
+
+        Room room1 = new Room(1L, roomSetting1, gameSetting, host1);
+        Room room2 = new Room(2L, roomSetting2, gameSetting, host2);
+
+        roomRepository.saveRoom(room1);
+        roomRepository.saveRoom(room2);
+
+        // when: 방 전체 조회 메서드로 전체 방 리스트 조회
+        List<Room> allRooms = roomRepository.findAll();
+
+        // then: 저장한 방 2개가 모두 조회되어야하고
+        assertThat(allRooms).hasSize(2);
+        assertThat(allRooms).extracting("id").containsExactlyInAnyOrder(1L, 2L);
+        assertThat(allRooms).extracting(room -> room.getRoomSetting().roomName()).containsExactlyInAnyOrder("방이름_1", "방이름_2");
+
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #14 

## 🪐 작업 내용
- 임시로 아래와 같이 사용하도록 User, Quiz 엔티티에 Setter 어노테이션 추가했습니다.
```
    public RoomListResponse getAllRooms() {
        List<Room> rooms = roomRepository.findAll();
        List<RoomResponse> roomResponses =
                rooms.stream()
                        .map(
                                room -> {
                                    User user = new User(); // 임시 유저 객체
                                    user.setNickname("임시 유저 닉네임");

                                    Quiz quiz = new Quiz(); // 임시 퀴즈 객체
                                    quiz.setTitle("임시 퀴즈 제목");
                                    quiz.setDescription("임시 퀴즈 설명");
                                    quiz.setThumbnailUrl("임시 이미지");
                                    quiz.setQuestions(List.of());
                                    quiz.setCreator(user);

                                    return RoomMapper.toRoomResponse(room, quiz);
                                })
                        .toList();
        return new RoomListResponse(roomResponses);
    }
```
- RoomListResponse DTO를 추가했습니다.(RoomResponse DTO를 리스트로 가지고 있는 구조입니다!)
- RoomMapper 클래스에 toRoomResponse 메서드를 추가했습니다. (Room 및 Room의 Quiz의 정보를 DTO로 변환 역할)
- 전체 룸 조회 API를 구현했습니다.
- RoomRepository 전체 룸 조회 테스트를 추가했습니다.

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?