### PR TITLE
[feat] 퀴즈 생성 기능 추가 

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### .idea ###
 .idea
+
+### images/thumbnail ###
+images/thumbnail/**

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -8,7 +8,9 @@ import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.question.mapper.QuestionMapper;
 import io.f1.backend.domain.question.mapper.TextQuestionMapper;
 import io.f1.backend.domain.quiz.entity.Quiz;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,11 +28,9 @@ public class QuestionService {
         quiz.addQuestion(question);
         questionRepository.save(question);
 
-        TextQuestion textQuestion = TextQuestionMapper.questionRequestToTextQuestion(question, request.getContent());
+        TextQuestion textQuestion =
+                TextQuestionMapper.questionRequestToTextQuestion(question, request.getContent());
         textQuestionRepository.save(textQuestion);
         question.addTextQuestion(textQuestion);
-
     }
-
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -1,0 +1,36 @@
+package io.f1.backend.domain.question.app;
+
+import io.f1.backend.domain.question.dao.QuestionRepository;
+import io.f1.backend.domain.question.dao.TextQuestionRepository;
+import io.f1.backend.domain.question.dto.QuestionRequest;
+import io.f1.backend.domain.question.entity.Question;
+import io.f1.backend.domain.question.entity.TextQuestion;
+import io.f1.backend.domain.question.mapper.QuestionMapper;
+import io.f1.backend.domain.question.mapper.TextQuestionMapper;
+import io.f1.backend.domain.quiz.entity.Quiz;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final TextQuestionRepository textQuestionRepository;
+
+    @Transactional
+    public void saveQuestion(Quiz quiz, QuestionRequest request) {
+
+        Question question = QuestionMapper.questionRequestToQuestion(quiz, request);
+        quiz.addQuestion(question);
+        questionRepository.save(question);
+
+        TextQuestion textQuestion = TextQuestionMapper.questionRequestToTextQuestion(question, request.getContent());
+        textQuestionRepository.save(textQuestion);
+        question.addTextQuestion(textQuestion);
+
+    }
+
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -1,12 +1,13 @@
 package io.f1.backend.domain.question.app;
 
+import static io.f1.backend.domain.question.mapper.QuestionMapper.questionRequestToQuestion;
+import static io.f1.backend.domain.question.mapper.TextQuestionMapper.questionRequestToTextQuestion;
+
 import io.f1.backend.domain.question.dao.QuestionRepository;
 import io.f1.backend.domain.question.dao.TextQuestionRepository;
 import io.f1.backend.domain.question.dto.QuestionRequest;
 import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
-import io.f1.backend.domain.question.mapper.QuestionMapper;
-import io.f1.backend.domain.question.mapper.TextQuestionMapper;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
 import lombok.RequiredArgsConstructor;
@@ -24,12 +25,12 @@ public class QuestionService {
     @Transactional
     public void saveQuestion(Quiz quiz, QuestionRequest request) {
 
-        Question question = QuestionMapper.questionRequestToQuestion(quiz, request);
+        Question question = questionRequestToQuestion(quiz, request);
         quiz.addQuestion(question);
         questionRepository.save(question);
 
         TextQuestion textQuestion =
-                TextQuestionMapper.questionRequestToTextQuestion(question, request.getContent());
+                questionRequestToTextQuestion(question, request.getContent());
         textQuestionRepository.save(textQuestion);
         question.addTextQuestion(textQuestion);
     }

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -29,8 +29,7 @@ public class QuestionService {
         quiz.addQuestion(question);
         questionRepository.save(question);
 
-        TextQuestion textQuestion =
-                questionRequestToTextQuestion(question, request.getContent());
+        TextQuestion textQuestion = questionRequestToTextQuestion(question, request.getContent());
         textQuestionRepository.save(textQuestion);
         question.addTextQuestion(textQuestion);
     }

--- a/backend/src/main/java/io/f1/backend/domain/question/dao/QuestionRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dao/QuestionRepository.java
@@ -1,8 +1,7 @@
 package io.f1.backend.domain.question.dao;
 
 import io.f1.backend.domain.question.entity.Question;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface QuestionRepository extends JpaRepository<Question, Long> {
-
-}
+public interface QuestionRepository extends JpaRepository<Question, Long> {}

--- a/backend/src/main/java/io/f1/backend/domain/question/dao/QuestionRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dao/QuestionRepository.java
@@ -1,0 +1,8 @@
+package io.f1.backend.domain.question.dao;
+
+import io.f1.backend.domain.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/dao/TextQuestionRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dao/TextQuestionRepository.java
@@ -1,0 +1,8 @@
+package io.f1.backend.domain.question.dao;
+
+import io.f1.backend.domain.question.entity.TextQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TextQuestionRepository extends JpaRepository<TextQuestion, Long> {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/dao/TextQuestionRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dao/TextQuestionRepository.java
@@ -1,8 +1,7 @@
 package io.f1.backend.domain.question.dao;
 
 import io.f1.backend.domain.question.entity.TextQuestion;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TextQuestionRepository extends JpaRepository<TextQuestion, Long> {
-
-}
+public interface TextQuestionRepository extends JpaRepository<TextQuestion, Long> {}

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
@@ -1,18 +1,18 @@
 package io.f1.backend.domain.question.dto;
 
 import jakarta.validation.constraints.NotBlank;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionRequest {
 
-    @NotBlank(message="문제를 입력해주세요.")
+    @NotBlank(message = "문제를 입력해주세요.")
     private String content;
 
-    @NotBlank(message="정답을 입력해주세요.")
+    @NotBlank(message = "정답을 입력해주세요.")
     private String answer;
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
@@ -1,0 +1,18 @@
+package io.f1.backend.domain.question.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class QuestionRequest {
+
+    @NotBlank(message="문제를 입력해주세요.")
+    private String content;
+
+    @NotBlank(message="정답을 입력해주세요.")
+    private String answer;
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
@@ -13,11 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseEntity {
 
     @Id
@@ -33,13 +34,13 @@ public class Question extends BaseEntity {
 
     @OneToOne(mappedBy = "question", cascade = CascadeType.REMOVE)
     private TextQuestion textQuestion;
-	public Question(Quiz quiz, String answer) {
-		this.quiz = quiz;
-		this.answer = answer;
-	}
 
-	public void addTextQuestion(TextQuestion textQuestion) {
-		this.textQuestion = textQuestion;
-	}
+    public Question(Quiz quiz, String answer) {
+        this.quiz = quiz;
+        this.answer = answer;
+    }
 
+    public void addTextQuestion(TextQuestion textQuestion) {
+        this.textQuestion = textQuestion;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
@@ -13,8 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class Question extends BaseEntity {
 
     @Id
@@ -30,4 +33,13 @@ public class Question extends BaseEntity {
 
     @OneToOne(mappedBy = "question", cascade = CascadeType.REMOVE)
     private TextQuestion textQuestion;
+	public Question(Quiz quiz, String answer) {
+		this.quiz = quiz;
+		this.answer = answer;
+	}
+
+	public void addTextQuestion(TextQuestion textQuestion) {
+		this.textQuestion = textQuestion;
+	}
+
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
@@ -7,11 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TextQuestion {
 
     @Id
@@ -25,8 +26,8 @@ public class TextQuestion {
     @Column(nullable = false)
     private String content;
 
-	public TextQuestion(Question question, String content) {
-		this.question = question;
-		this.content = content;
-	}
+    public TextQuestion(Question question, String content) {
+        this.question = question;
+        this.content = content;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
@@ -7,8 +7,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class TextQuestion {
 
     @Id
@@ -21,4 +24,9 @@ public class TextQuestion {
 
     @Column(nullable = false)
     private String content;
+
+	public TextQuestion(Question question, String content) {
+		this.question = question;
+		this.content = content;
+	}
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/mapper/QuestionMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/mapper/QuestionMapper.java
@@ -1,0 +1,13 @@
+package io.f1.backend.domain.question.mapper;
+
+import io.f1.backend.domain.question.dto.QuestionRequest;
+import io.f1.backend.domain.question.entity.Question;
+import io.f1.backend.domain.quiz.entity.Quiz;
+
+public class QuestionMapper {
+
+    public static Question questionRequestToQuestion(Quiz quiz, QuestionRequest questionRequest) {
+        return new Question(quiz, questionRequest.getAnswer());
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/mapper/QuestionMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/mapper/QuestionMapper.java
@@ -9,5 +9,4 @@ public class QuestionMapper {
     public static Question questionRequestToQuestion(Quiz quiz, QuestionRequest questionRequest) {
         return new Question(quiz, questionRequest.getAnswer());
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/mapper/TextQuestionMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/mapper/TextQuestionMapper.java
@@ -8,5 +8,4 @@ public class TextQuestionMapper {
     public static TextQuestion questionRequestToTextQuestion(Question question, String content) {
         return new TextQuestion(question, content);
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/mapper/TextQuestionMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/mapper/TextQuestionMapper.java
@@ -1,0 +1,12 @@
+package io.f1.backend.domain.question.mapper;
+
+import io.f1.backend.domain.question.entity.Question;
+import io.f1.backend.domain.question.entity.TextQuestion;
+
+public class TextQuestionMapper {
+
+    public static TextQuestion questionRequestToTextQuestion(Question question, String content) {
+        return new TextQuestion(question, content);
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -3,9 +3,11 @@ package io.f1.backend.domain.quiz.api;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
 import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
+
 import jakarta.validation.Valid;
-import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @RestController
 @RequestMapping("/quizzes")
 @RequiredArgsConstructor
@@ -23,10 +27,12 @@ public class QuizController {
     private final QuizService quizService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<QuizCreateResponse> saveQuiz(@RequestPart(required = false) MultipartFile file, @Valid @RequestPart QuizCreateRequest request) throws IOException {
+    public ResponseEntity<QuizCreateResponse> saveQuiz(
+            @RequestPart(required = false) MultipartFile file,
+            @Valid @RequestPart QuizCreateRequest request)
+            throws IOException {
         QuizCreateResponse response = quizService.saveQuiz(file, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -1,0 +1,32 @@
+package io.f1.backend.domain.quiz.api;
+
+import io.f1.backend.domain.quiz.app.QuizService;
+import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
+import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
+import jakarta.validation.Valid;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/quizzes")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<QuizCreateResponse> saveQuiz(@RequestPart(required = false) MultipartFile file, @Valid @RequestPart QuizCreateRequest request) throws IOException {
+        QuizCreateResponse response = quizService.saveQuiz(file, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -28,10 +28,10 @@ public class QuizController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<QuizCreateResponse> saveQuiz(
-            @RequestPart(required = false) MultipartFile file,
+            @RequestPart(required = false) MultipartFile thumbnailFile,
             @Valid @RequestPart QuizCreateRequest request)
             throws IOException {
-        QuizCreateResponse response = quizService.saveQuiz(file, request);
+        QuizCreateResponse response = quizService.saveQuiz(thumbnailFile, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -41,13 +41,13 @@ public class QuizService {
     private final QuizRepository quizRepository;
 
     @Transactional
-    public QuizCreateResponse saveQuiz(MultipartFile file, QuizCreateRequest request)
+    public QuizCreateResponse saveQuiz(MultipartFile thumbnailFile, QuizCreateRequest request)
             throws IOException {
         String thumbnailPath = defaultThumbnailPath;
 
-        if (file != null && !file.isEmpty()) {
-            validateImageFile(file);
-            thumbnailPath = convertToThumbnailPath(file);
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            validateImageFile(thumbnailFile);
+            thumbnailPath = convertToThumbnailPath(thumbnailFile);
         }
 
         // TODO : 시큐리티 구현 이후 삭제 (data.sql로 초기 저장해둔 유저 get), 나중엔 현재 로그인한 유저의 아이디를 받아오도록 수정
@@ -64,26 +64,26 @@ public class QuizService {
         return quizToQuizCreateResponse(savedQuiz);
     }
 
-    private void validateImageFile(MultipartFile file) {
+    private void validateImageFile(MultipartFile thumbnailFile) {
 
-        if (!file.getContentType().startsWith("image")) {
+        if (!thumbnailFile.getContentType().startsWith("image")) {
             // TODO : 이후 커스텀 예외로 변경
             throw new IllegalArgumentException("이미지 파일을 업로드해주세요.");
         }
 
         List<String> allowedExt = List.of("jpg", "jpeg", "png", "webp");
-        if (!allowedExt.contains(getExtension(file.getOriginalFilename()))) {
+        if (!allowedExt.contains(getExtension(thumbnailFile.getOriginalFilename()))) {
             throw new IllegalArgumentException("지원하지 않는 확장자입니다.");
         }
     }
 
-    private String convertToThumbnailPath(MultipartFile file) throws IOException {
-        String originalFilename = file.getOriginalFilename();
+    private String convertToThumbnailPath(MultipartFile thumbnailFile) throws IOException {
+        String originalFilename = thumbnailFile.getOriginalFilename();
         String ext = getExtension(originalFilename);
         String savedFilename = UUID.randomUUID().toString() + "." + ext;
 
         Path savePath = Paths.get(uploadPath, savedFilename).toAbsolutePath();
-        file.transferTo(savePath.toFile());
+        thumbnailFile.transferTo(savePath.toFile());
 
         return "/images/thumbnail/" + savedFilename;
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -9,17 +9,19 @@ import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.quiz.mapper.QuizMapper;
 import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.entity.User;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -37,10 +39,11 @@ public class QuizService {
     private final QuizRepository quizRepository;
 
     @Transactional
-    public QuizCreateResponse saveQuiz(MultipartFile file, QuizCreateRequest request) throws IOException {
+    public QuizCreateResponse saveQuiz(MultipartFile file, QuizCreateRequest request)
+            throws IOException {
         String imgUrl = defaultThumbnailPath;
 
-        if(file!=null && !file.isEmpty()) {
+        if (file != null && !file.isEmpty()) {
             validateImageFile(file);
             imgUrl = saveThumbnail(file);
         }
@@ -52,7 +55,7 @@ public class QuizService {
 
         Quiz savedQuiz = quizRepository.save(quiz);
 
-        for(QuestionRequest qRequest : request.getQuestions()) {
+        for (QuestionRequest qRequest : request.getQuestions()) {
             questionService.saveQuestion(savedQuiz, qRequest);
         }
 
@@ -61,13 +64,13 @@ public class QuizService {
 
     private void validateImageFile(MultipartFile file) {
 
-        if(!file.getContentType().startsWith("image")) {
+        if (!file.getContentType().startsWith("image")) {
             // TODO : 이후 커스텀 예외로 변경
             throw new IllegalArgumentException("이미지 파일을 업로드해주세요.");
         }
 
         List<String> allowedExt = List.of("jpg", "jpeg", "png", "webp");
-        if(!allowedExt.contains(getExtension(file.getOriginalFilename()))) {
+        if (!allowedExt.contains(getExtension(file.getOriginalFilename()))) {
             throw new IllegalArgumentException("지원하지 않는 확장자입니다.");
         }
     }
@@ -86,5 +89,4 @@ public class QuizService {
     private String getExtension(String filename) {
         return filename.substring(filename.lastIndexOf(".") + 1);
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -1,0 +1,90 @@
+package io.f1.backend.domain.quiz.app;
+
+import io.f1.backend.domain.question.app.QuestionService;
+import io.f1.backend.domain.question.dto.QuestionRequest;
+import io.f1.backend.domain.quiz.dao.QuizRepository;
+import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
+import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
+import io.f1.backend.domain.quiz.entity.Quiz;
+import io.f1.backend.domain.quiz.mapper.QuizMapper;
+import io.f1.backend.domain.user.dao.UserRepository;
+import io.f1.backend.domain.user.entity.User;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    @Value("${file.thumbnail-path}")
+    private String uploadPath;
+
+    @Value("${file.default-thumbnail-url}")
+    private String defaultThumbnailPath;
+
+    // TODO : 시큐리티 구현 이후 삭제해도 되는 의존성 주입
+    private final UserRepository userRepository;
+    private final QuestionService questionService;
+    private final QuizRepository quizRepository;
+
+    @Transactional
+    public QuizCreateResponse saveQuiz(MultipartFile file, QuizCreateRequest request) throws IOException {
+        String imgUrl = defaultThumbnailPath;
+
+        if(file!=null && !file.isEmpty()) {
+            validateImageFile(file);
+            imgUrl = saveThumbnail(file);
+        }
+
+        // TODO : 시큐리티 구현 이후 삭제 (data.sql로 초기 저장해둔 유저 get), 나중엔 현재 로그인한 유저의 아이디를 받아오도록 수정
+        User user = userRepository.findById(1L).orElseThrow(RuntimeException::new);
+
+        Quiz quiz = QuizMapper.quizCreateRequestToQuiz(request, imgUrl, user);
+
+        Quiz savedQuiz = quizRepository.save(quiz);
+
+        for(QuestionRequest qRequest : request.getQuestions()) {
+            questionService.saveQuestion(savedQuiz, qRequest);
+        }
+
+        return QuizMapper.quizToQuizCreateResponse(savedQuiz);
+    }
+
+    private void validateImageFile(MultipartFile file) {
+
+        if(!file.getContentType().startsWith("image")) {
+            // TODO : 이후 커스텀 예외로 변경
+            throw new IllegalArgumentException("이미지 파일을 업로드해주세요.");
+        }
+
+        List<String> allowedExt = List.of("jpg", "jpeg", "png", "webp");
+        if(!allowedExt.contains(getExtension(file.getOriginalFilename()))) {
+            throw new IllegalArgumentException("지원하지 않는 확장자입니다.");
+        }
+    }
+
+    private String saveThumbnail(MultipartFile file) throws IOException {
+        String originalFilename = file.getOriginalFilename();
+        String ext = getExtension(originalFilename);
+        String savedFilename = UUID.randomUUID().toString() + "." + ext;
+
+        Path savePath = Paths.get(uploadPath, savedFilename).toAbsolutePath();
+        file.transferTo(savePath.toFile());
+
+        return "/images/thumbnail/" + savedFilename;
+    }
+
+    private String getExtension(String filename) {
+        return filename.substring(filename.lastIndexOf(".") + 1);
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dao/QuizRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dao/QuizRepository.java
@@ -1,8 +1,7 @@
 package io.f1.backend.domain.quiz.dao;
 
 import io.f1.backend.domain.quiz.entity.Quiz;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface QuizRepository extends JpaRepository<Quiz, Long> {
-
-}
+public interface QuizRepository extends JpaRepository<Quiz, Long> {}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dao/QuizRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dao/QuizRepository.java
@@ -1,0 +1,8 @@
+package io.f1.backend.domain.quiz.dao;
+
+import io.f1.backend.domain.quiz.entity.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
@@ -1,0 +1,26 @@
+package io.f1.backend.domain.quiz.dto;
+
+import io.f1.backend.domain.question.dto.QuestionRequest;
+import io.f1.backend.domain.quiz.entity.QuizType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class QuizCreateRequest {
+
+    @NotBlank(message="퀴즈 제목을 설정해주세요.")
+    private String title;
+    @NotNull(message="퀴즈 종류를 선택해주세요.")
+    private QuizType quizType;
+    @NotBlank(message="퀴즈 설명을 적어주세요.")
+    private String description;
+    @Size(min = 10, max=80, message = "문제는 최소 10개, 최대 80개로 정해주세요.")
+    private List<QuestionRequest> questions;
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
@@ -2,25 +2,30 @@ package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.question.dto.QuestionRequest;
 import io.f1.backend.domain.quiz.entity.QuizType;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuizCreateRequest {
 
-    @NotBlank(message="퀴즈 제목을 설정해주세요.")
+    @NotBlank(message = "퀴즈 제목을 설정해주세요.")
     private String title;
-    @NotNull(message="퀴즈 종류를 선택해주세요.")
-    private QuizType quizType;
-    @NotBlank(message="퀴즈 설명을 적어주세요.")
-    private String description;
-    @Size(min = 10, max=80, message = "문제는 최소 10개, 최대 80개로 정해주세요.")
-    private List<QuestionRequest> questions;
 
+    @NotNull(message = "퀴즈 종류를 선택해주세요.")
+    private QuizType quizType;
+
+    @NotBlank(message = "퀴즈 설명을 적어주세요.")
+    private String description;
+
+    @Size(min = 10, max = 80, message = "문제는 최소 10개, 최대 80개로 정해주세요.")
+    private List<QuestionRequest> questions;
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateResponse.java
@@ -2,4 +2,10 @@ package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.quiz.entity.QuizType;
 
-public record QuizCreateResponse(Long id, String title, QuizType quizType, String description, String thumbnailUrl, Long creatorId) {}
+public record QuizCreateResponse(
+        Long id,
+        String title,
+        QuizType quizType,
+        String description,
+        String thumbnailUrl,
+        Long creatorId) {}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateResponse.java
@@ -1,0 +1,5 @@
+package io.f1.backend.domain.quiz.dto;
+
+import io.f1.backend.domain.quiz.entity.QuizType;
+
+public record QuizCreateResponse(Long id, String title, QuizType quizType, String description, String thumbnailUrl, Long creatorId) {}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -16,16 +16,17 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Quiz extends BaseEntity {
 
     @Id
@@ -52,18 +53,21 @@ public class Quiz extends BaseEntity {
     @JoinColumn(name = "creator_id")
     private User creator;
 
-	@Builder
-	public Quiz(String title, String description, QuizType quizType, String thumbnailUrl,
-		User creator) {
-		this.title = title;
-		this.description = description;
-		this.quizType = quizType;
-		this.thumbnailUrl = thumbnailUrl;
-		this.creator = creator;
-	}
+    @Builder
+    public Quiz(
+            String title,
+            String description,
+            QuizType quizType,
+            String thumbnailUrl,
+            User creator) {
+        this.title = title;
+        this.description = description;
+        this.quizType = quizType;
+        this.thumbnailUrl = thumbnailUrl;
+        this.creator = creator;
+    }
 
-	public void addQuestion(Question question) {
-		this.questions.add(question);
-	}
-
+    public void addQuestion(Question question) {
+        this.questions.add(question);
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -18,8 +18,14 @@ import jakarta.persistence.OneToMany;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class Quiz extends BaseEntity {
 
     @Id
@@ -45,4 +51,19 @@ public class Quiz extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "creator_id")
     private User creator;
+
+	@Builder
+	public Quiz(String title, String description, QuizType quizType, String thumbnailUrl,
+		User creator) {
+		this.title = title;
+		this.description = description;
+		this.quizType = quizType;
+		this.thumbnailUrl = thumbnailUrl;
+		this.creator = creator;
+	}
+
+	public void addQuestion(Question question) {
+		this.questions.add(question);
+	}
+
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -27,8 +27,7 @@ import java.util.List;
 @Getter
 @Setter // quizService의 퀴즈 조회 메서드 구현 시까지 임시 사용
 @Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class Quiz extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -53,7 +53,6 @@ public class Quiz extends BaseEntity {
     @JoinColumn(name = "creator_id")
     private User creator;
 
-    @Builder
     public Quiz(
             String title,
             String description,

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -17,7 +17,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -16,7 +16,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -11,13 +11,13 @@ public class QuizMapper {
     public static Quiz quizCreateRequestToQuiz(
             QuizCreateRequest quizCreateRequest, String imgUrl, User user) {
 
-        return Quiz.builder()
-                .title(quizCreateRequest.getTitle())
-                .description(quizCreateRequest.getDescription())
-                .quizType(quizCreateRequest.getQuizType())
-                .thumbnailUrl(imgUrl)
-                .creator(user) // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
-                .build();
+        return new Quiz(
+            quizCreateRequest.getTitle(),
+            quizCreateRequest.getDescription(),
+            quizCreateRequest.getQuizType(),
+            imgUrl,
+            user // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
+        );
     }
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -12,12 +12,12 @@ public class QuizMapper {
             QuizCreateRequest quizCreateRequest, String imgUrl, User user) {
 
         return new Quiz(
-            quizCreateRequest.getTitle(),
-            quizCreateRequest.getDescription(),
-            quizCreateRequest.getQuizType(),
-            imgUrl,
-            user // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
-        );
+                quizCreateRequest.getTitle(),
+                quizCreateRequest.getDescription(),
+                quizCreateRequest.getQuizType(),
+                imgUrl,
+                user // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
+                );
     }
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -1,0 +1,28 @@
+package io.f1.backend.domain.quiz.mapper;
+
+import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
+import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
+import io.f1.backend.domain.quiz.entity.Quiz;
+import io.f1.backend.domain.user.entity.User;
+
+public class QuizMapper {
+
+    // TODO : 이후 파라미터에서 user 삭제하기
+    public static Quiz quizCreateRequestToQuiz(QuizCreateRequest quizCreateRequest, String imgUrl, User user) {
+
+        return Quiz.builder()
+            .title(quizCreateRequest.getTitle())
+            .description(quizCreateRequest.getDescription())
+            .quizType(quizCreateRequest.getQuizType())
+            .thumbnailUrl(imgUrl)
+            .creator(user) // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
+            .build();
+    }
+
+    public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {
+        // TODO : creatorId 넣어주는 부분에서 Getter를 안 쓰고, 현재 로그인한 유저의 id를 담는 식으로 바꿔도 될 듯
+        return new QuizCreateResponse(quiz.getId(), quiz.getTitle(), quiz.getQuizType(),
+            quiz.getDescription(), quiz.getThumbnailUrl(), quiz.getCreator().getId());
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -8,21 +8,26 @@ import io.f1.backend.domain.user.entity.User;
 public class QuizMapper {
 
     // TODO : 이후 파라미터에서 user 삭제하기
-    public static Quiz quizCreateRequestToQuiz(QuizCreateRequest quizCreateRequest, String imgUrl, User user) {
+    public static Quiz quizCreateRequestToQuiz(
+            QuizCreateRequest quizCreateRequest, String imgUrl, User user) {
 
         return Quiz.builder()
-            .title(quizCreateRequest.getTitle())
-            .description(quizCreateRequest.getDescription())
-            .quizType(quizCreateRequest.getQuizType())
-            .thumbnailUrl(imgUrl)
-            .creator(user) // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
-            .build();
+                .title(quizCreateRequest.getTitle())
+                .description(quizCreateRequest.getDescription())
+                .quizType(quizCreateRequest.getQuizType())
+                .thumbnailUrl(imgUrl)
+                .creator(user) // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
+                .build();
     }
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {
         // TODO : creatorId 넣어주는 부분에서 Getter를 안 쓰고, 현재 로그인한 유저의 id를 담는 식으로 바꿔도 될 듯
-        return new QuizCreateResponse(quiz.getId(), quiz.getTitle(), quiz.getQuizType(),
-            quiz.getDescription(), quiz.getThumbnailUrl(), quiz.getCreator().getId());
+        return new QuizCreateResponse(
+                quiz.getId(),
+                quiz.getTitle(),
+                quiz.getQuizType(),
+                quiz.getDescription(),
+                quiz.getThumbnailUrl(),
+                quiz.getCreator().getId());
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -1,0 +1,9 @@
+package io.f1.backend.domain.user.dao;
+
+import io.f1.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// TODO : 퀴즈 생성을 위한 user 생성을 위해 임의로 만듦.
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -1,9 +1,8 @@
 package io.f1.backend.domain.user.dao;
 
 import io.f1.backend.domain.user.entity.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // TODO : 퀴즈 생성을 위한 user 생성을 위해 임의로 만듦.
-public interface UserRepository extends JpaRepository<User, Long> {
-
-}
+public interface UserRepository extends JpaRepository<User, Long> {}

--- a/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
@@ -13,8 +13,10 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "`user`")
 public class User extends BaseEntity {
 

--- a/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
@@ -12,8 +12,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import java.time.LocalDateTime;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
@@ -20,7 +20,6 @@ import java.time.LocalDateTime;
 @Getter
 @Setter // quizService의 퀴즈 조회 메서드 구현 시까지 임시 사용
 @Entity
-@Getter
 @Table(name = "`user`")
 public class User extends BaseEntity {
 

--- a/backend/src/main/java/io/f1/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/WebConfig.java
@@ -1,3 +1,17 @@
 package io.f1.backend.global.config;
 
-public class WebConfig {}
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 클라이언트가 /image/thumbnail/~~ 로 요청
+        // 실제 서버 경로 images/thumbnail/ 에서 리소스 찾아서 응답
+        registry.addResourceHandler("/images/thumbnail/**")
+                .addResourceLocations("file:images/thumbnail/");
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
+  sql:
+    init:
+      mode: always # 현재는 data.sql 에서 더미 유저 자동 추가를 위해 넣어뒀음.
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url : ${DB_URL}
@@ -14,6 +18,7 @@ spring:
       port: ${REDIS_PORT}
 
   jpa:
+    defer-datasource-initialization: true # 현재는 data.sql 에서 더미 유저 자동 추가를 위해 넣어뒀음.
     hibernate:
       ddl-auto: create
 
@@ -21,3 +26,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+
+file:
+  thumbnail-path : images/thumbnail/ # 이후 배포 환경에서는 바꾸면 될 듯
+  default-thumbnail-url: /images/thumbnail/default.png

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO user (id, nickname, provider, provider_id, last_login)
+VALUES (1, 'test-user', 'kakao', 'kakao-1234', NOW());

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -3,3 +3,11 @@ spring:
     url: jdbc:h2:mem:testdb;MODE=MYSQL
     username: sa
     password:
+
+  sql:
+    init:
+      mode: never
+
+file:
+  thumbnail-path : images/thumbnail/ # 이후 배포 환경에서는 바꾸면 될 듯
+  default-thumbnail-url: /images/thumbnail/default.png


### PR DESCRIPTION
## 🛰️ Issue Number
- #4 

## 🪐 작업 내용

### 1. 퀴즈 생성 API 

퀴즈 생성 API를 생성했습니다. 
<img width="844" height="620" alt="스크린샷 2025-07-13 오전 3 44 35" src="https://github.com/user-attachments/assets/d246f242-6dda-4021-ac2a-4b9b59d7b973" />


- Postman 에서도 정상적으로 생성되는 것을 확인했습니다. 
- 이 부분은 테스트 코드를 지금 짜둬도 이후 시큐리티 구현 이후 변경되는 부분이 많을 것 같아 이후 테스트 코드를 작성하도록 하겠습니다. 

### 2. 유의점

아직 시큐리티가 적용되어있지 않아, User는 하드 코딩해서 넣어주었습니다. 
저희는 db client 콘솔으로 INSERT 문을 실행하는 게 쉽지만, 혹시나 프론트 개발자님이 그 부분이 어려우실까봐 `application.yml`에 

```
spring:
  sql:
    init:
      mode: always # 현재는 data.sql 에서 더미 유저 자동 추가를 위해 넣어뒀음.
  jpa:
    defer-datasource-initialization: true # 현재는 data.sql 에서 더미 유저 자동 추가를 위해 넣어뒀음.
```

이 부분을 추가해두었습니다. 

`resources/data.sql`에는 Stat이 비워져있는 `id=1`인 User를 INSERT 해두었습니다. 

- 또, 많은 부분에서 Quiz 생성에 필요한 `User creator` 때문에 TODO 주석이 있습니다. 참고바랍니다.

### 3. 이미지 저장 경로

- 프로젝트의 루트 경로에서 `images/thumbnail/` 에 저장됩니다. 
- `application.yml`에서 퀴즈 썸네일 디폴트 이미지 경로도 설정해두었습니다. 환경에서는 임의의 default.png를 두고 테스트를 진행했습니다.

### 4. 확장성 관련

- 아직 확장성을 고려해서 코드를 작성하진 않았습니다. 
- 퀴즈 생성 이외에 수정, 삭제 등의 API 를 추가 구현하면서 더 고민해보고 리팩토링을 해보도록 하겠습니다. 


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] Postman으로 테스트 했는지?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?