### PR TITLE
[feat] Kakao OAuth 회원가입, 로그인, 로그아웃 기능

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	/* DATABASE */
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -39,6 +41,7 @@ dependencies {
 	testImplementation 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testRuntimeOnly 'com.h2database:h2'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	/* ETC */
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/io/f1/backend/domain/stat/entity/Stat.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/entity/Stat.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/io/f1/backend/domain/stat/entity/Stat.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/entity/Stat.java
@@ -11,8 +11,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stat extends BaseEntity {
 
     @Id
@@ -31,4 +35,12 @@ public class Stat extends BaseEntity {
 
     @Column(nullable = false)
     private Long score;
+
+    @Builder
+    public Stat(User user, Long totalGames, Long winningGames, Long score) {
+        this.user = user;
+        this.totalGames = totalGames;
+        this.winningGames = winningGames;
+        this.score = score;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
@@ -1,0 +1,26 @@
+package io.f1.backend.domain.user.api;
+
+import io.f1.backend.domain.user.app.UserService;
+import io.f1.backend.domain.user.dto.SignupRequestDto;
+import io.f1.backend.domain.user.dto.SignupResponseDto;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SignupController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseDto> completeSignup(
+        @RequestBody SignupRequestDto signupRequest, HttpSession httpSession) {
+        SignupResponseDto response = userService.signup(httpSession, signupRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
@@ -3,8 +3,11 @@ package io.f1.backend.domain.user.api;
 import io.f1.backend.domain.user.app.UserService;
 import io.f1.backend.domain.user.dto.SignupRequestDto;
 import io.f1.backend.domain.user.dto.SignupResponseDto;
+
 import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +22,7 @@ public class SignupController {
 
     @PostMapping("/signup")
     public ResponseEntity<SignupResponseDto> completeSignup(
-        @RequestBody SignupRequestDto signupRequest, HttpSession httpSession) {
+            @RequestBody SignupRequestDto signupRequest, HttpSession httpSession) {
         SignupResponseDto response = userService.signup(httpSession, signupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/backend/src/main/java/io/f1/backend/domain/user/app/CustomOAuthUserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/CustomOAuthUserService.java
@@ -5,16 +5,20 @@ import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.dto.SessionUser;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
+
 import jakarta.servlet.http.HttpSession;
-import java.time.LocalDateTime;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -31,9 +35,11 @@ public class CustomOAuthUserService extends DefaultOAuth2UserService {
         String provider = userRequest.getClientRegistration().getRegistrationId();
         String providerId = Objects.requireNonNull(oAuth2User.getAttribute("id")).toString();
 
-        User user = userRepository.findByProviderAndProviderId(provider, providerId)
-            .map(this::updateLastLogin)
-            .orElseGet(() -> createNewUser(provider, providerId));
+        User user =
+                userRepository
+                        .findByProviderAndProviderId(provider, providerId)
+                        .map(this::updateLastLogin)
+                        .orElseGet(() -> createNewUser(provider, providerId));
 
         httpSession.setAttribute("OAuthUser", new SessionUser(user));
         return new UserPrincipal(user, oAuth2User.getAttributes());
@@ -45,18 +51,14 @@ public class CustomOAuthUserService extends DefaultOAuth2UserService {
     }
 
     private User createNewUser(String provider, String providerId) {
-        User user = User.builder()
-            .provider(provider)
-            .providerId(providerId)
-            .lastLogin(LocalDateTime.now())
-            .build();
+        User user =
+                User.builder()
+                        .provider(provider)
+                        .providerId(providerId)
+                        .lastLogin(LocalDateTime.now())
+                        .build();
 
-        Stat stat = Stat.builder()
-            .totalGames(0L)
-            .winningGames(0L)
-            .score(0L)
-            .user(user)
-            .build();
+        Stat stat = Stat.builder().totalGames(0L).winningGames(0L).score(0L).user(user).build();
 
         user.initStat(stat);
         return userRepository.save(user);

--- a/backend/src/main/java/io/f1/backend/domain/user/app/CustomOAuthUserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/CustomOAuthUserService.java
@@ -1,0 +1,64 @@
+package io.f1.backend.domain.user.app;
+
+import io.f1.backend.domain.stat.entity.Stat;
+import io.f1.backend.domain.user.dao.UserRepository;
+import io.f1.backend.domain.user.dto.SessionUser;
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import io.f1.backend.domain.user.entity.User;
+import jakarta.servlet.http.HttpSession;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuthUserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        String providerId = Objects.requireNonNull(oAuth2User.getAttribute("id")).toString();
+
+        User user = userRepository.findByProviderAndProviderId(provider, providerId)
+            .map(this::updateLastLogin)
+            .orElseGet(() -> createNewUser(provider, providerId));
+
+        httpSession.setAttribute("OAuthUser", new SessionUser(user));
+        return new UserPrincipal(user, oAuth2User.getAttributes());
+    }
+
+    private User updateLastLogin(User user) {
+        user.updateLastLogin(LocalDateTime.now());
+        return userRepository.save(user);
+    }
+
+    private User createNewUser(String provider, String providerId) {
+        User user = User.builder()
+            .provider(provider)
+            .providerId(providerId)
+            .lastLogin(LocalDateTime.now())
+            .build();
+
+        Stat stat = Stat.builder()
+            .totalGames(0L)
+            .winningGames(0L)
+            .score(0L)
+            .user(user)
+            .build();
+
+        user.initStat(stat);
+        return userRepository.save(user);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
@@ -1,0 +1,73 @@
+package io.f1.backend.domain.user.app;
+
+import io.f1.backend.domain.user.dao.UserRepository;
+import io.f1.backend.domain.user.dto.SessionUser;
+import io.f1.backend.domain.user.dto.SignupRequestDto;
+import io.f1.backend.domain.user.dto.SignupResponseDto;
+import io.f1.backend.domain.user.entity.User;
+import io.f1.backend.global.util.SecurityUtils;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public SignupResponseDto signup(HttpSession session, SignupRequestDto signupRequest) {
+        SessionUser sessionUser = extractSessionUser(session);
+
+        String nickname = signupRequest.nickname();
+        validateNickname(nickname);
+        validateDuplicateNickname(nickname);
+
+        User user = updateUserNickname(sessionUser.getUserId(), nickname);
+        updateSessionAfterSignup(session, user);
+        SecurityUtils.setAuthentication(user);
+
+        return SignupResponseDto.toDto(user);
+    }
+
+    private SessionUser extractSessionUser(HttpSession session) {
+        SessionUser sessionUser = (SessionUser) session.getAttribute("OAuthUser");
+        if (sessionUser == null) {
+            throw new RuntimeException("세션에 OAuth 정보 없음");
+        }
+        return sessionUser;
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new RuntimeException("E400002: 닉네임은 필수 입력입니다.");
+        }
+        if (nickname.length() > 6) {
+            throw new RuntimeException("E400003: 닉네임은 6글자 이하로 입력해야 합니다.");
+        }
+        if (!nickname.matches("^[가-힣a-zA-Z0-9]+$")) {
+            throw new RuntimeException("E400004: 한글, 영문, 숫자만 입력해주세요.");
+        }
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (userRepository.existsUserByNickname(nickname)) {
+            throw new RuntimeException("닉네임 중복");
+        }
+    }
+
+    private User updateUserNickname(Long userId, String nickname) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        user.updateNickname(nickname);
+
+        return userRepository.save(user);
+    }
+
+    private void updateSessionAfterSignup(HttpSession session, User user) {
+        session.removeAttribute("OAuthUser");
+        session.setAttribute("user", new SessionUser(user));
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
@@ -6,8 +6,11 @@ import io.f1.backend.domain.user.dto.SignupRequestDto;
 import io.f1.backend.domain.user.dto.SignupResponseDto;
 import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.util.SecurityUtils;
+
 import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,8 +62,8 @@ public class UserService {
     }
 
     private User updateUserNickname(Long userId, String nickname) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        User user =
+                userRepository.findById(userId).orElseThrow(() -> new RuntimeException("사용자 없음"));
         user.updateNickname(nickname);
 
         return userRepository.save(user);

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/CustomAuthenticationEntryPoint.java
@@ -2,17 +2,22 @@ package io.f1.backend.domain.user.app.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException authException) throws IOException {
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
         response.getWriter().write("{\"error\": \"Unauthorized\"}");

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package io.f1.backend.domain.user.app.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.getWriter().write("{\"error\": \"Unauthorized\"}");
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthLogoutSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthLogoutSuccessHandler.java
@@ -2,6 +2,7 @@ package io.f1.backend.domain.user.app.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -10,8 +11,10 @@ import org.springframework.stereotype.Component;
 public class OAuthLogoutSuccessHandler implements LogoutSuccessHandler {
 
     @Override
-    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) {
+    public void onLogoutSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) {
         response.setStatus(HttpServletResponse.SC_NO_CONTENT); // 204
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthLogoutSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthLogoutSuccessHandler.java
@@ -1,0 +1,17 @@
+package io.f1.backend.domain.user.app.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuthLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) {
+        response.setStatus(HttpServletResponse.SC_NO_CONTENT); // 204
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthSuccessHandler.java
@@ -1,0 +1,41 @@
+package io.f1.backend.domain.user.app.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException {
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        response.setContentType("application/json;charset=UTF-8");
+
+        if (principal.getUserNickname() == null) {
+            // 닉네임 설정 필요 → 202 Accepted
+            response.setStatus(HttpServletResponse.SC_ACCEPTED);
+            objectMapper.writeValue(response.getWriter(), Map.of(
+                "message", "닉네임을 설정하세요."
+            ));
+        } else {
+            // 정상 로그인 → 200 OK
+            response.setStatus(HttpServletResponse.SC_OK);
+            objectMapper.writeValue(response.getWriter(), Map.of(
+                "message", "로그인 성공"
+            ));
+        }
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/OAuthSuccessHandler.java
@@ -1,16 +1,20 @@
 package io.f1.backend.domain.user.app.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.f1.backend.domain.user.dto.UserPrincipal;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import java.io.IOException;
-import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -19,23 +23,20 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) throws IOException {
+    public void onAuthenticationSuccess(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
         response.setContentType("application/json;charset=UTF-8");
 
         if (principal.getUserNickname() == null) {
             // 닉네임 설정 필요 → 202 Accepted
             response.setStatus(HttpServletResponse.SC_ACCEPTED);
-            objectMapper.writeValue(response.getWriter(), Map.of(
-                "message", "닉네임을 설정하세요."
-            ));
+            objectMapper.writeValue(response.getWriter(), Map.of("message", "닉네임을 설정하세요."));
         } else {
             // 정상 로그인 → 200 OK
             response.setStatus(HttpServletResponse.SC_OK);
-            objectMapper.writeValue(response.getWriter(), Map.of(
-                "message", "로그인 성공"
-            ));
+            objectMapper.writeValue(response.getWriter(), Map.of("message", "로그인 성공"));
         }
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -1,0 +1,14 @@
+package io.f1.backend.domain.user.dao;
+
+import io.f1.backend.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+    Boolean existsUserByNickname(String nickname);
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -1,9 +1,11 @@
 package io.f1.backend.domain.user.dao;
 
 import io.f1.backend.domain.user.entity.User;
-import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -3,7 +3,6 @@ package io.f1.backend.domain.user.dao;
 import io.f1.backend.domain.user.entity.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/SessionUser.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/SessionUser.java
@@ -1,0 +1,22 @@
+package io.f1.backend.domain.user.dto;
+
+import io.f1.backend.domain.user.entity.User;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class SessionUser implements Serializable {
+
+    private final Long userId;
+    private final String nickname;
+    private final String providerId;
+    private final LocalDateTime lastLogin;
+
+    public SessionUser(User user) {
+        this.userId = user.getId();
+        this.nickname = user.getNickname();
+        this.providerId = user.getProviderId();
+        this.lastLogin = user.getLastLogin();
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/SessionUser.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/SessionUser.java
@@ -1,9 +1,11 @@
 package io.f1.backend.domain.user.dto;
 
 import io.f1.backend.domain.user.entity.User;
+
+import lombok.Getter;
+
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import lombok.Getter;
 
 @Getter
 public class SessionUser implements Serializable {

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/SignupRequestDto.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/SignupRequestDto.java
@@ -1,0 +1,7 @@
+package io.f1.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequestDto(@NotBlank(message = "닉네임을 입력하세요") String nickname) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/SignupRequestDto.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/SignupRequestDto.java
@@ -2,6 +2,4 @@ package io.f1.backend.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record SignupRequestDto(@NotBlank(message = "닉네임을 입력하세요") String nickname) {
-
-}
+public record SignupRequestDto(@NotBlank(message = "닉네임을 입력하세요") String nickname) {}

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/SignupResponseDto.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/SignupResponseDto.java
@@ -1,0 +1,24 @@
+package io.f1.backend.domain.user.dto;
+
+import io.f1.backend.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupResponseDto {
+
+    private Long id;
+    private String nickname;
+
+    public static SignupResponseDto toDto(User user) {
+        return SignupResponseDto.builder()
+            .id(user.getId())
+            .nickname(user.getNickname())
+            .build();
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/SignupResponseDto.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/SignupResponseDto.java
@@ -1,6 +1,7 @@
 package io.f1.backend.domain.user.dto;
 
 import io.f1.backend.domain.user.entity.User;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,9 +17,6 @@ public class SignupResponseDto {
     private String nickname;
 
     public static SignupResponseDto toDto(User user) {
-        return SignupResponseDto.builder()
-            .id(user.getId())
-            .nickname(user.getNickname())
-            .build();
+        return SignupResponseDto.builder().id(user.getId()).nickname(user.getNickname()).build();
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/UserPrincipal.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/UserPrincipal.java
@@ -1,13 +1,16 @@
 package io.f1.backend.domain.user.dto;
 
 import io.f1.backend.domain.user.entity.User;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
+
 import lombok.Getter;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 @Getter
 public class UserPrincipal implements UserDetails, OAuth2User {

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/UserPrincipal.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/UserPrincipal.java
@@ -1,0 +1,76 @@
+package io.f1.backend.domain.user.dto;
+
+import io.f1.backend.domain.user.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+public class UserPrincipal implements UserDetails, OAuth2User {
+
+    public static final String ROLE_USER = "ROLE_USER";
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public UserPrincipal(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    public String getUserNickname() {
+        return user.getNickname();
+    }
+
+    @Override
+    public String getName() {
+        return user.getProviderId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> ROLE_USER);
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // 소셜 로그인이라 비밀번호 없음
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getProviderId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
@@ -12,7 +12,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -21,6 +24,7 @@ import java.time.LocalDateTime;
 @Setter // quizService의 퀴즈 조회 메서드 구현 시까지 임시 사용
 @Entity
 @Table(name = "`user`")
+@NoArgsConstructor
 public class User extends BaseEntity {
 
     @Id
@@ -30,7 +34,7 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private Stat stat;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String nickname;
 
     @Column(nullable = false)
@@ -41,4 +45,23 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime lastLogin;
+
+    @Builder
+    public User(String provider, String providerId, LocalDateTime lastLogin) {
+        this.provider = provider;
+        this.providerId = providerId;
+        this.lastLogin = lastLogin;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateLastLogin(LocalDateTime lastLogin) {
+        this.lastLogin = lastLogin;
+    }
+
+    public void initStat(Stat stat) {
+        this.stat = stat;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/entity/User.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -1,10 +1,12 @@
 package io.f1.backend.global.config;
 
-import io.f1.backend.domain.user.app.handler.CustomAuthenticationEntryPoint;
 import io.f1.backend.domain.user.app.CustomOAuthUserService;
+import io.f1.backend.domain.user.app.handler.CustomAuthenticationEntryPoint;
 import io.f1.backend.domain.user.app.handler.OAuthLogoutSuccessHandler;
 import io.f1.backend.domain.user.app.handler.OAuthSuccessHandler;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,31 +26,39 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(AbstractHttpConfigurer::disable)
-            .exceptionHandling(exception -> exception
-                .authenticationEntryPoint(customAuthenticationEntryPoint)
-            )
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/oauth2/**", "/signup", "/css/**", "/js/**")
-                .permitAll()
-                .requestMatchers("/ws/**").authenticated()
-                .anyRequest().authenticated()
-            )
-            .formLogin(AbstractHttpConfigurer::disable)
-            .oauth2Login(oauth2 -> oauth2
-                .userInfoEndpoint(userInfo -> userInfo
-                    .userService(customOAuthUserService)
-                )
-                .successHandler(oAuthSuccessHandler)
-            )
-            .logout(logout -> logout
-                .logoutUrl("/logout")
-                .logoutSuccessHandler(oAuthLogoutSuccessHandler)
-                .clearAuthentication(true)
-                .invalidateHttpSession(true)
-                .permitAll()
-            );
+        http.csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(
+                        exception ->
+                                exception.authenticationEntryPoint(customAuthenticationEntryPoint))
+                .authorizeHttpRequests(
+                        auth ->
+                                auth.requestMatchers(
+                                                "/",
+                                                "/login",
+                                                "/oauth2/**",
+                                                "/signup",
+                                                "/css/**",
+                                                "/js/**")
+                                        .permitAll()
+                                        .requestMatchers("/ws/**")
+                                        .authenticated()
+                                        .anyRequest()
+                                        .authenticated())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .oauth2Login(
+                        oauth2 ->
+                                oauth2.userInfoEndpoint(
+                                                userInfo ->
+                                                        userInfo.userService(
+                                                                customOAuthUserService))
+                                        .successHandler(oAuthSuccessHandler))
+                .logout(
+                        logout ->
+                                logout.logoutUrl("/logout")
+                                        .logoutSuccessHandler(oAuthLogoutSuccessHandler)
+                                        .clearAuthentication(true)
+                                        .invalidateHttpSession(true)
+                                        .permitAll());
         return http.build();
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package io.f1.backend.global.config;
+
+import io.f1.backend.domain.user.app.handler.CustomAuthenticationEntryPoint;
+import io.f1.backend.domain.user.app.CustomOAuthUserService;
+import io.f1.backend.domain.user.app.handler.OAuthLogoutSuccessHandler;
+import io.f1.backend.domain.user.app.handler.OAuthSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomOAuthUserService customOAuthUserService;
+    private final OAuthSuccessHandler oAuthSuccessHandler;
+    private final OAuthLogoutSuccessHandler oAuthLogoutSuccessHandler;
+
+    @Bean
+    public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(customAuthenticationEntryPoint)
+            )
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/", "/login", "/oauth2/**", "/signup", "/css/**", "/js/**")
+                .permitAll()
+                .requestMatchers("/ws/**").authenticated()
+                .anyRequest().authenticated()
+            )
+            .formLogin(AbstractHttpConfigurer::disable)
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuthUserService)
+                )
+                .successHandler(oAuthSuccessHandler)
+            )
+            .logout(logout -> logout
+                .logoutUrl("/logout")
+                .logoutSuccessHandler(oAuthLogoutSuccessHandler)
+                .clearAuthentication(true)
+                .invalidateHttpSession(true)
+                .permitAll()
+            );
+        return http.build();
+    }
+}

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -1,0 +1,22 @@
+package io.f1.backend.global.util;
+
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import io.f1.backend.domain.user.entity.User;
+import java.util.Collections;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    private SecurityUtils() {
+
+    }
+
+    public static void setAuthentication(User user) {
+        UserPrincipal userPrincipal = new UserPrincipal(user, Collections.emptyMap());
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(userPrincipal, null,
+                userPrincipal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -2,21 +2,21 @@ package io.f1.backend.global.util;
 
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
-import java.util.Collections;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.Collections;
+
 public class SecurityUtils {
 
-    private SecurityUtils() {
-
-    }
+    private SecurityUtils() {}
 
     public static void setAuthentication(User user) {
         UserPrincipal userPrincipal = new UserPrincipal(user, Collections.emptyMap());
         UsernamePasswordAuthenticationToken authentication =
-            new UsernamePasswordAuthenticationToken(userPrincipal, null,
-                userPrincipal.getAuthorities());
+                new UsernamePasswordAuthenticationToken(
+                        userPrincipal, null, userPrincipal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url : ${DB_URL}
+    url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
@@ -21,3 +21,22 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: Kakao
+            client-id: ${KAKAO_CLIENT}
+            client-secret: ${KAKAO_SECRET}
+            redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
## 🛰️ Issue Number
- #2 

## 🪐 작업 내용
- Kakao OAuth 회원가입, 로그인, 로그아웃 기능을 구현했습니다.
- 아직 커스텀 예외처리는 적용하지 않았습니다.
- Kakao OAuth 애플리케이션 정보는 수업 시간에 생성했던 환경을 그대로 사용했습니다. 이 부분도 어떻게 관리할 지 논의가 필요해보입니다.
- 제가 구현한 기능의 흐름은 다음과 같습니다
    - 뇌이싱 시작하기 버튼 클릭 → /oauth2/authorization/kakao 으로 요청 → Kakao 로그인 화면에서 ID/Password 입력 후 OAuth 인증 → 닉네임 설정 페이지에서 닉네임 입력 후 /signup 요청 → 회원가입 완료
    - 만약 Kakao OAuth 인증만 한 상태로 닉네임 설정을 하지 않으면 User 테이블에 nickname이 null인 user가 생성됨 → 그래서 사용자 정보를 불러와서 nickname이 null인 사용자면 닉네임 설정 페이지로 분기 되도록 json 응답 처리
        - 이것에 대한 json 응답은 API 명세서에 추가했습니다.
```java
@Override
    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
        Authentication authentication) throws IOException {
        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
        response.setContentType("application/json;charset=UTF-8");

        if (principal.getUserNickname() == null) {
            // 닉네임 설정 필요 → 202 Accepted
            response.setStatus(HttpServletResponse.SC_ACCEPTED);
            objectMapper.writeValue(response.getWriter(), Map.of(
                "message", "닉네임을 설정하세요."
            ));
        } else {
            // 정상 로그인 → 200 OK
            response.setStatus(HttpServletResponse.SC_OK);
            objectMapper.writeValue(response.getWriter(), Map.of(
                "message", "로그인 성공"
            ));
        }
    }
```
- 혹시 몰라서 인증 정보는 세션과 SecurityContextHolder 두 군데 모두 저장했습니다.
```java
private void updateSessionAfterSignup(HttpSession session, User user) {
        session.removeAttribute("OAuthUser");
        session.setAttribute("user", new SessionUser(user));
    }
```
```java
 public static void setAuthentication(User user) {
        UserPrincipal userPrincipal = new UserPrincipal(user, Collections.emptyMap());
        UsernamePasswordAuthenticationToken authentication =
            new UsernamePasswordAuthenticationToken(userPrincipal, null,
                userPrincipal.getAuthorities());
        SecurityContextHolder.getContext().setAuthentication(authentication);
    }
```
- handler가 많이 추가돼서 service/handler로 한 번더 패키지를 분리했습니다.
- SessionUser, UserPrincipal 모두 값을 저장하고 전달하는 역할 수행하기 때문에 dto 패키지에 생성했습니다.
- Mapper를 추가하지 않아서 관련 리팩토링 작업은 다음 이슈에서 진행하겠습니다
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?