### PR TITLE
[feat] SSE 알림 기능 구현

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -12,17 +12,19 @@ import io.f1.backend.domain.game.dto.response.RoomCreateResponse;
 import io.f1.backend.domain.game.dto.response.RoomListResponse;
 import io.f1.backend.domain.game.dto.response.RoomResponse;
 import io.f1.backend.domain.game.dto.response.RoomSettingResponse;
+import io.f1.backend.domain.game.event.RoomCreatedEvent;
 import io.f1.backend.domain.game.model.GameSetting;
 import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomSetting;
 import io.f1.backend.domain.game.model.RoomState;
 import io.f1.backend.domain.game.store.RoomRepository;
+import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
-import io.f1.backend.domain.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -33,8 +35,10 @@ import java.util.concurrent.atomic.AtomicLong;
 @RequiredArgsConstructor
 public class RoomService {
 
+    private final QuizService quizService;
     private final RoomRepository roomRepository;
     private final AtomicLong roomIdGenerator = new AtomicLong(0);
+    private final ApplicationEventPublisher eventPublisher;
 
     public RoomCreateResponse saveRoom(RoomCreateRequest request, Map<String, Object> loginUser) {
 
@@ -46,7 +50,14 @@ public class RoomService {
 
         Long newId = roomIdGenerator.incrementAndGet();
 
-        roomRepository.saveRoom(new Room(newId, roomSetting, gameSetting, host));
+        Room room = new Room(newId, roomSetting, gameSetting, host);
+
+        roomRepository.saveRoom(room);
+
+        Long quizId = room.getGameSetting().getQuizId();
+        Quiz quiz = quizService.getQuizById(quizId);
+
+        eventPublisher.publishEvent(new RoomCreatedEvent(room, quiz));
 
         return new RoomCreateResponse(newId);
     }
@@ -103,26 +114,16 @@ public class RoomService {
                 destination, roomSettingResponse, gameSettingResponse, playerListResponse);
     }
 
-    // todo quizService에서 퀴즈 조회 메서드로 변경
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
-        List<RoomResponse> roomResponses =
-                rooms.stream()
-                        .map(
-                                room -> {
-                                    User user = new User(); // 임시 유저 객체
-                                    user.setNickname("임시 유저 닉네임");
+        List<RoomResponse> roomResponses = rooms.stream()
+            .map(room -> {
+                Long quizId = room.getGameSetting().getQuizId();
+                Quiz quiz = quizService.getQuizById(quizId);
 
-                                    Quiz quiz = new Quiz(); // 임시 퀴즈 객체
-                                    quiz.setTitle("임시 퀴즈 제목");
-                                    quiz.setDescription("임시 퀴즈 설명");
-                                    quiz.setThumbnailUrl("임시 이미지");
-                                    quiz.setQuestions(List.of());
-                                    quiz.setCreator(user);
-
-                                    return toRoomResponse(room, quiz);
-                                })
-                        .toList();
+                return toRoomResponse(room, quiz);
+                })
+            .toList();
         return new RoomListResponse(roomResponses);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -116,14 +116,16 @@ public class RoomService {
 
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
-        List<RoomResponse> roomResponses = rooms.stream()
-            .map(room -> {
-                Long quizId = room.getGameSetting().getQuizId();
-                Quiz quiz = quizService.getQuizById(quizId);
+        List<RoomResponse> roomResponses =
+                rooms.stream()
+                        .map(
+                                room -> {
+                                    Long quizId = room.getGameSetting().getQuizId();
+                                    Quiz quiz = quizService.getQuizById(quizId);
 
-                return toRoomResponse(room, quiz);
-                })
-            .toList();
+                                    return toRoomResponse(room, quiz);
+                                })
+                        .toList();
         return new RoomListResponse(roomResponses);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomCreatedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomCreatedEvent.java
@@ -3,6 +3,4 @@ package io.f1.backend.domain.game.event;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
-public record RoomCreatedEvent(Room room, Quiz quiz) {
-}
-
+public record RoomCreatedEvent(Room room, Quiz quiz) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomCreatedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomCreatedEvent.java
@@ -1,0 +1,8 @@
+package io.f1.backend.domain.game.event;
+
+import io.f1.backend.domain.game.model.Room;
+import io.f1.backend.domain.quiz.entity.Quiz;
+
+public record RoomCreatedEvent(Room room, Quiz quiz) {
+}
+

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomDeletedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomDeletedEvent.java
@@ -1,0 +1,5 @@
+package io.f1.backend.domain.game.event;
+
+public record RoomDeletedEvent(Long roomId) {
+}
+

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomDeletedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomDeletedEvent.java
@@ -1,5 +1,3 @@
 package io.f1.backend.domain.game.event;
 
-public record RoomDeletedEvent(Long roomId) {
-}
-
+public record RoomDeletedEvent(Long roomId) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomUpdatedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomUpdatedEvent.java
@@ -1,0 +1,7 @@
+package io.f1.backend.domain.game.event;
+
+import io.f1.backend.domain.game.model.Room;
+import io.f1.backend.domain.quiz.entity.Quiz;
+
+public record RoomUpdatedEvent(Room room, Quiz quiz) {
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomUpdatedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomUpdatedEvent.java
@@ -3,5 +3,4 @@ package io.f1.backend.domain.game.event;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
-public record RoomUpdatedEvent(Room room, Quiz quiz) {
-}
+public record RoomUpdatedEvent(Room room, Quiz quiz) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
@@ -34,10 +34,7 @@ public class SseService {
     public <T> void notifyLobbyUpdate(LobbySseEvent<T> event) {
         for (SseEmitter emitter : emitterRepository.getAll()) {
             try {
-                emitter.send(SseEmitter.event()
-                    .name(event.type())
-                    .data(event)
-                );
+                emitter.send(SseEmitter.event().name(event.type()).data(event));
             } catch (IOException e) {
                 emitterRepository.remove(emitter);
             }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
@@ -1,5 +1,6 @@
 package io.f1.backend.domain.game.sse.app;
 
+import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
 import io.f1.backend.domain.game.sse.store.SseEmitterRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,5 +28,19 @@ public class SseService {
             emitterRepository.remove(emitter);
         }
         return emitter;
+    }
+
+    // 로비로 SSE 메시지를 쏘기위한 메서드
+    public <T> void notifyLobbyUpdate(LobbySseEvent<T> event) {
+        for (SseEmitter emitter : emitterRepository.getAll()) {
+            try {
+                emitter.send(SseEmitter.event()
+                    .name(event.type())
+                    .data(event)
+                );
+            } catch (IOException e) {
+                emitterRepository.remove(emitter);
+            }
+        }
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/LobbySseEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/LobbySseEvent.java
@@ -1,4 +1,3 @@
 package io.f1.backend.domain.game.sse.dto;
 
-public record LobbySseEvent<T>(String type, T payload) {
-}
+public record LobbySseEvent<T>(String type, T payload) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/LobbySseEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/LobbySseEvent.java
@@ -1,0 +1,4 @@
+package io.f1.backend.domain.game.sse.dto;
+
+public record LobbySseEvent<T>(String type, T payload) {
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
@@ -1,14 +1,17 @@
 package io.f1.backend.domain.game.sse.dto;
 
 public record RoomCreatedPayload(
-        Long roomId,
-        String roomName,
-        Integer maxUserCount,
-        int currentUserCount,
-        boolean locked,
-        String roomState,
-        String quizTitle,
-        String description,
-        String creator,
-        Integer numberOfQuestion,
-        String thumbnailUrl) {}
+    Long roomId,
+    String roomName,
+    int maxUserCount,
+    int currentUserCount,
+    boolean locked,
+    String roomState,
+    String quizTitle,
+    String description,
+    String creator,
+    int numberOfQuestion,
+    String thumbnailUrl
+) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
@@ -1,17 +1,14 @@
 package io.f1.backend.domain.game.sse.dto;
 
 public record RoomCreatedPayload(
-    Long roomId,
-    String roomName,
-    int maxUserCount,
-    int currentUserCount,
-    boolean locked,
-    String roomState,
-    String quizTitle,
-    String description,
-    String creator,
-    int numberOfQuestion,
-    String thumbnailUrl
-) {
-
-}
+        Long roomId,
+        String roomName,
+        int maxUserCount,
+        int currentUserCount,
+        boolean locked,
+        String roomState,
+        String quizTitle,
+        String description,
+        String creator,
+        int numberOfQuestion,
+        String thumbnailUrl) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
@@ -1,0 +1,17 @@
+package io.f1.backend.domain.game.sse.dto;
+
+public record RoomCreatedPayload(
+    Long roomId,
+    String roomName,
+    Integer maxUserCount,
+    int currentUserCount,
+    boolean locked,
+    String roomState,
+    String quizTitle,
+    String description,
+    String creator,
+    Integer numberOfQuestion,
+    String thumbnailUrl
+) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
@@ -1,17 +1,14 @@
 package io.f1.backend.domain.game.sse.dto;
 
 public record RoomCreatedPayload(
-    Long roomId,
-    String roomName,
-    Integer maxUserCount,
-    int currentUserCount,
-    boolean locked,
-    String roomState,
-    String quizTitle,
-    String description,
-    String creator,
-    Integer numberOfQuestion,
-    String thumbnailUrl
-) {
-
-}
+        Long roomId,
+        String roomName,
+        Integer maxUserCount,
+        int currentUserCount,
+        boolean locked,
+        String roomState,
+        String quizTitle,
+        String description,
+        String creator,
+        Integer numberOfQuestion,
+        String thumbnailUrl) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomDeletedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomDeletedPayload.java
@@ -1,5 +1,3 @@
 package io.f1.backend.domain.game.sse.dto;
 
-public record RoomDeletedPayload(Long roomId) {
-
-}
+public record RoomDeletedPayload(Long roomId) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomDeletedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomDeletedPayload.java
@@ -1,0 +1,5 @@
+package io.f1.backend.domain.game.sse.dto;
+
+public record RoomDeletedPayload(Long roomId) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomUpdatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomUpdatedPayload.java
@@ -1,0 +1,13 @@
+package io.f1.backend.domain.game.sse.dto;
+
+public record RoomUpdatedPayload(
+    Long roomId,
+    int currentUserCount,
+    String roomState,
+    String quizTitle,
+    String description,
+    String creator,
+    int numberOfQuestion,
+    String thumbnailUrl
+) {
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomUpdatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomUpdatedPayload.java
@@ -1,13 +1,11 @@
 package io.f1.backend.domain.game.sse.dto;
 
 public record RoomUpdatedPayload(
-    Long roomId,
-    int currentUserCount,
-    String roomState,
-    String quizTitle,
-    String description,
-    String creator,
-    int numberOfQuestion,
-    String thumbnailUrl
-) {
-}
+        Long roomId,
+        int currentUserCount,
+        String roomState,
+        String quizTitle,
+        String description,
+        String creator,
+        int numberOfQuestion,
+        String thumbnailUrl) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/SseEventType.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/SseEventType.java
@@ -1,0 +1,7 @@
+package io.f1.backend.domain.game.sse.dto;
+
+public enum SseEventType {
+    CREATE,
+    UPDATE,
+    DELETE
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomCreatedEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomCreatedEventListener.java
@@ -1,15 +1,17 @@
 package io.f1.backend.domain.game.sse.listener;
 
+import static io.f1.backend.domain.game.sse.mapper.SseMapper.*;
+
 import io.f1.backend.domain.game.event.RoomCreatedEvent;
 import io.f1.backend.domain.game.sse.app.SseService;
 import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
 import io.f1.backend.domain.game.sse.dto.RoomCreatedPayload;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-
-import static io.f1.backend.domain.game.sse.mapper.SseMapper.*;
 
 @Component
 @RequiredArgsConstructor
@@ -23,5 +25,4 @@ public class RoomCreatedEventListener {
         LobbySseEvent<RoomCreatedPayload> sseEvent = fromRoomCreated(event);
         sseService.notifyLobbyUpdate(sseEvent);
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomCreatedEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomCreatedEventListener.java
@@ -1,0 +1,27 @@
+package io.f1.backend.domain.game.sse.listener;
+
+import io.f1.backend.domain.game.event.RoomCreatedEvent;
+import io.f1.backend.domain.game.sse.app.SseService;
+import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
+import io.f1.backend.domain.game.sse.dto.RoomCreatedPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import static io.f1.backend.domain.game.sse.mapper.SseMapper.*;
+
+@Component
+@RequiredArgsConstructor
+public class RoomCreatedEventListener {
+
+    private final SseService sseService;
+
+    @Async
+    @EventListener
+    public void roomCreate(RoomCreatedEvent event) {
+        LobbySseEvent<RoomCreatedPayload> sseEvent = fromRoomCreated(event);
+        sseService.notifyLobbyUpdate(sseEvent);
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomDeletedEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomDeletedEventListener.java
@@ -1,14 +1,16 @@
 package io.f1.backend.domain.game.sse.listener;
 
+import static io.f1.backend.domain.game.sse.mapper.SseMapper.*;
+
 import io.f1.backend.domain.game.event.RoomDeletedEvent;
 import io.f1.backend.domain.game.sse.app.SseService;
 import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
 import io.f1.backend.domain.game.sse.dto.RoomDeletedPayload;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
-
-import static io.f1.backend.domain.game.sse.mapper.SseMapper.*;
 
 @RequiredArgsConstructor
 public class RoomDeletedEventListener {

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomDeletedEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomDeletedEventListener.java
@@ -1,0 +1,24 @@
+package io.f1.backend.domain.game.sse.listener;
+
+import io.f1.backend.domain.game.event.RoomDeletedEvent;
+import io.f1.backend.domain.game.sse.app.SseService;
+import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
+import io.f1.backend.domain.game.sse.dto.RoomDeletedPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+import static io.f1.backend.domain.game.sse.mapper.SseMapper.*;
+
+@RequiredArgsConstructor
+public class RoomDeletedEventListener {
+
+    private final SseService sseService;
+
+    @Async
+    @EventListener
+    public void roomDelete(RoomDeletedEvent event) {
+        LobbySseEvent<RoomDeletedPayload> sseEvent = fromRoomDeleted(event);
+        sseService.notifyLobbyUpdate(sseEvent);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomUpdatedEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomUpdatedEventListener.java
@@ -1,0 +1,23 @@
+package io.f1.backend.domain.game.sse.listener;
+
+import io.f1.backend.domain.game.event.RoomUpdatedEvent;
+import io.f1.backend.domain.game.sse.app.SseService;
+import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
+import io.f1.backend.domain.game.sse.dto.RoomUpdatedPayload;
+import io.f1.backend.domain.game.sse.mapper.SseMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+@RequiredArgsConstructor
+public class RoomUpdatedEventListener {
+
+    private final SseService sseService;
+
+    @Async
+    @EventListener
+    public void roomUpdate(RoomUpdatedEvent event) {
+        LobbySseEvent<RoomUpdatedPayload> sseEvent = SseMapper.fromRoomUpdated(event);
+        sseService.notifyLobbyUpdate(sseEvent);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomUpdatedEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/listener/RoomUpdatedEventListener.java
@@ -5,7 +5,9 @@ import io.f1.backend.domain.game.sse.app.SseService;
 import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
 import io.f1.backend.domain.game.sse.dto.RoomUpdatedPayload;
 import io.f1.backend.domain.game.sse.mapper.SseMapper;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
@@ -1,0 +1,56 @@
+package io.f1.backend.domain.game.sse.mapper;
+
+import io.f1.backend.domain.game.event.RoomCreatedEvent;
+import io.f1.backend.domain.game.event.RoomDeletedEvent;
+import io.f1.backend.domain.game.event.RoomUpdatedEvent;
+import io.f1.backend.domain.game.model.Room;
+import io.f1.backend.domain.game.sse.dto.RoomCreatedPayload;
+import io.f1.backend.domain.game.sse.dto.RoomDeletedPayload;
+import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
+import io.f1.backend.domain.game.sse.dto.RoomUpdatedPayload;
+import io.f1.backend.domain.game.sse.dto.SseEventType;
+import io.f1.backend.domain.quiz.entity.Quiz;
+
+public class SseMapper {
+
+    public static LobbySseEvent<RoomCreatedPayload> fromRoomCreated(RoomCreatedEvent event) {
+        Room room = event.room();
+        Quiz quiz = event.quiz();
+        RoomCreatedPayload payload = new RoomCreatedPayload(
+            room.getId(),
+            room.getRoomSetting().roomName(),
+            room.getRoomSetting().maxUserCount(),
+            room.getPlayerSessionMap().size(),
+            room.getRoomSetting().locked(),
+            room.getState().name(),
+            quiz.getTitle(),
+            quiz.getDescription(),
+            quiz.getCreator().getNickname(),
+            quiz.getQuestions().size(),
+            quiz.getThumbnailUrl()
+        );
+        return new LobbySseEvent<>(SseEventType.CREATE.name(), payload);
+    }
+
+    public static LobbySseEvent<RoomUpdatedPayload> fromRoomUpdated(RoomUpdatedEvent event) {
+        Room room = event.room();
+        Quiz quiz = event.quiz();
+        RoomUpdatedPayload payload = new RoomUpdatedPayload(
+            room.getId(),
+            room.getPlayerSessionMap().size(),
+            room.getState().name(),
+            quiz.getTitle(),
+            quiz.getDescription(),
+            quiz.getCreator().getNickname(),
+            quiz.getQuestions().size(),
+            quiz.getThumbnailUrl()
+        );
+        return new LobbySseEvent<>(SseEventType.UPDATE.name(), payload);
+    }
+
+    public static LobbySseEvent<RoomDeletedPayload> fromRoomDeleted(RoomDeletedEvent event) {
+        Long roomId = event.roomId();
+        RoomDeletedPayload payload = new RoomDeletedPayload(roomId);
+        return new LobbySseEvent<>(SseEventType.DELETE.name(), payload);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
@@ -4,9 +4,9 @@ import io.f1.backend.domain.game.event.RoomCreatedEvent;
 import io.f1.backend.domain.game.event.RoomDeletedEvent;
 import io.f1.backend.domain.game.event.RoomUpdatedEvent;
 import io.f1.backend.domain.game.model.Room;
+import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
 import io.f1.backend.domain.game.sse.dto.RoomCreatedPayload;
 import io.f1.backend.domain.game.sse.dto.RoomDeletedPayload;
-import io.f1.backend.domain.game.sse.dto.LobbySseEvent;
 import io.f1.backend.domain.game.sse.dto.RoomUpdatedPayload;
 import io.f1.backend.domain.game.sse.dto.SseEventType;
 import io.f1.backend.domain.quiz.entity.Quiz;
@@ -16,35 +16,35 @@ public class SseMapper {
     public static LobbySseEvent<RoomCreatedPayload> fromRoomCreated(RoomCreatedEvent event) {
         Room room = event.room();
         Quiz quiz = event.quiz();
-        RoomCreatedPayload payload = new RoomCreatedPayload(
-            room.getId(),
-            room.getRoomSetting().roomName(),
-            room.getRoomSetting().maxUserCount(),
-            room.getPlayerSessionMap().size(),
-            room.getRoomSetting().locked(),
-            room.getState().name(),
-            quiz.getTitle(),
-            quiz.getDescription(),
-            quiz.getCreator().getNickname(),
-            quiz.getQuestions().size(),
-            quiz.getThumbnailUrl()
-        );
+        RoomCreatedPayload payload =
+                new RoomCreatedPayload(
+                        room.getId(),
+                        room.getRoomSetting().roomName(),
+                        room.getRoomSetting().maxUserCount(),
+                        room.getPlayerSessionMap().size(),
+                        room.getRoomSetting().locked(),
+                        room.getState().name(),
+                        quiz.getTitle(),
+                        quiz.getDescription(),
+                        quiz.getCreator().getNickname(),
+                        quiz.getQuestions().size(),
+                        quiz.getThumbnailUrl());
         return new LobbySseEvent<>(SseEventType.CREATE.name(), payload);
     }
 
     public static LobbySseEvent<RoomUpdatedPayload> fromRoomUpdated(RoomUpdatedEvent event) {
         Room room = event.room();
         Quiz quiz = event.quiz();
-        RoomUpdatedPayload payload = new RoomUpdatedPayload(
-            room.getId(),
-            room.getPlayerSessionMap().size(),
-            room.getState().name(),
-            quiz.getTitle(),
-            quiz.getDescription(),
-            quiz.getCreator().getNickname(),
-            quiz.getQuestions().size(),
-            quiz.getThumbnailUrl()
-        );
+        RoomUpdatedPayload payload =
+                new RoomUpdatedPayload(
+                        room.getId(),
+                        room.getPlayerSessionMap().size(),
+                        room.getState().name(),
+                        quiz.getTitle(),
+                        quiz.getDescription(),
+                        quiz.getCreator().getNickname(),
+                        quiz.getQuestions().size(),
+                        quiz.getThumbnailUrl());
         return new LobbySseEvent<>(SseEventType.UPDATE.name(), payload);
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/store/SseEmitterRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/store/SseEmitterRepository.java
@@ -14,10 +14,7 @@ public class SseEmitterRepository {
     public void save(SseEmitter emitter) {
         emitters.add(emitter);
         // 연결종료 객체정리
-        emitter.onCompletion(
-                () -> {
-                    emitters.remove(emitter);
-                });
+        emitter.onCompletion(() -> emitters.remove(emitter));
         emitter.onTimeout(() -> emitters.remove(emitter));
         emitter.onError(error -> emitters.remove(emitter));
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -93,7 +93,8 @@ public class QuizService {
     }
 
     public Quiz getQuizById(Long quizId) {
-        return quizRepository.findById(quizId)
-            .orElseThrow(() -> new RuntimeException("E404002: 존재하지 않는 퀴즈입니다."));
+        return quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new RuntimeException("E404002: 존재하지 않는 퀴즈입니다."));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -91,4 +91,9 @@ public class QuizService {
     private String getExtension(String filename) {
         return filename.substring(filename.lastIndexOf(".") + 1);
     }
+
+    public Quiz getQuizById(Long quizId) {
+        return quizRepository.findById(quizId)
+            .orElseThrow(() -> new RuntimeException("E404002: 존재하지 않는 퀴즈입니다."));
+    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #18 

## 🪐 작업 내용

### SSE 연결 종료 및 객체 정리 설명
```
        // 연결종료 객체정리
        emitter.onCompletion(() -> emitters.remove(emitter));
        emitter.onTimeout(() -> emitters.remove(emitter));
        emitter.onError(error -> emitters.remove(emitter));
```
이번 작업내용은 아니지만, emitter 객체 해제의 경우는 주석으로 적기에는 조금 길어서 이 부분에 적어두었습니다.
- **onCompletion 발생** -> 브라우저 종료, 새로고침시 자동으로 서버에서 호출됨 / 로비 페이지 벗어날 시에는 FE에서 close() 호출을 명시적으로 해줘야 서버에서 onCompletion 발생
- **onTimeout 발생**-> 해당 객체에 설정된 timeOut 종료 시, 서버에서 호출됨
- **onError**-> 네트워크 끊김 등 클라이언트 연결 예외 시 서버에서 호출됨


### SSE 플로우
1. Room의 생성, 수정, 삭제 메서드에서는 각 작업이 완료된 후, 해당 작업에 대응하는 이벤트 객체(RoomCreatedEvent, RoomUpdatedEvent, RoomDeletedEvent)를 발행합니다.

2. 이 이벤트들은 SseMapper를 통해 LobbySseEvent로 변환되며, 이 과정에서 이벤트 타입(CREATE, UPDATE, DELETE)이 지정되고, 클라이언트에게 전달할 payload가 구성됩니다.

3. 변환된 LobbySseEvent는 이벤트 리스너를 통해 SSE(로비에 있는 사용자)를 구독 중인 모든 클라이언트에게 브로드캐스팅됩니다.

### 변경 사항
- SSE 이벤트 타입을 enum클래스로 정의해두었습니다.
- 이벤트 객체 없이 이벤트리스너에 전달은 가능하지만 기능별 메시지 타입별로 책임분리를 위해, 나누어놓았습니다!
- 현재 방 생성 메서드에만 이벤트 퍼블리셔가 추가되어있습니다. 추후 방 수정, 방 삭제 로직이 완성되면 이벤트 퍼블리셔를 추가해 두겠습니다!
- 클라이언트의 SSE 연결을 무제한으로 유지하는 경우(생성된 emitter객체가 오래 유지되는 경우) emitter 객체를 잘 정리해준다면 문제가 되지는 않지만, 타임아웃을 설정하고 클라이언트에서 재연결 요청을 받는것이 안전한 방법이라고 합니다! 따라서 저도 30초 타임아웃을 유지하고 나중에 테스트 하면서 문제가 없다면 5분으로 늘릴 예정입니다!

### 테스트 사진
아래는 security 설정을 모두 끄고, 생성 SSE 메시지 알림 테스트 해보았습니다. 정상적으로 알림을 받는 것을 확인할 수 있습니다.
<img width="1470" height="475" alt="스크린샷 2025-07-14 오후 3 43 12" src="https://github.com/user-attachments/assets/f33fc421-8ec3-4187-9a94-2fb5538385c6" />


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?