### PR TITLE
[feat] Github Action 자동 도커 이미지 빌드 추가

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,12 @@
+name: release
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haya14busa/action-bumpr@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=raw,value=${{ needs.release.outputs.current_version }}
+            type=raw,value=${{ needs.release.outputs.next_version }}
 
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - labeled
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   release:
@@ -13,3 +14,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: haya14busa/action-bumpr@v1
+
+  package:
+    runs-on: ubuntu-latest
+    needs: release
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ needs.release.outputs.current_version }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,12 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      next_version: ${{ steps.bump.outputs.next_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: haya14busa/action-bumpr@v1
+        id: bump
 
   package:
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM gradle:jdk21 AS builder
+WORKDIR /app
+COPY . .
+RUN ./gradlew clean build -x test
+
+FROM openjdk:21-slim
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,10 +12,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+#  Redis 도입 시 정의
+#  data:
+#    redis:
+#      host: ${REDIS_HOST}
+#      port: ${REDIS_PORT}
 
   jpa:
     defer-datasource-initialization: true # 현재는 data.sql 에서 더미 유저 자동 추가를 위해 넣어뒀음.


### PR DESCRIPTION
## 🛰️ Issue Number
- #22 

## 🪐 작업 내용
- Dockerfile 정의
- versioning 작업을 bump-version workflow로 분리
- release workflow에 docker image 빌드 추가
- Redis 관련 설정 주석처리

## 📚 Reference
아래 forked repository에서 시험 완료했습니다.
https://github.com/dlsrks1021/WEB5_7_F1_BE/pull/5

도커 이미지 빌드를 위한 절차는 아래와 같습니다.
1. dev -> main으로의 PR 생성
2. 해당 PR에서 bump:patch, bump:minor, bump:major 중 1개 label 설정
3. PR merge 시 자동 이미지 빌드 -> packages에서 확인 가능

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?