### PR TITLE
[feat] 문제와 함께 퀴즈 조회 API 구현

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionResponse.java
@@ -1,3 +1,3 @@
 package io.f1.backend.domain.question.dto;
 
-public record QuestionResponse(Long id, String content, String answer) { }
+public record QuestionResponse(Long id, String content, String answer) {}

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionResponse.java
@@ -1,0 +1,3 @@
+package io.f1.backend.domain.question.dto;
+
+public record QuestionResponse(Long id, String content, String answer) { }

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
@@ -15,9 +15,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseEntity {
 

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
@@ -9,9 +9,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TextQuestion {
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -81,7 +81,8 @@ public class QuizController {
     }
 
     @GetMapping("/{quizId}")
-    public ResponseEntity<QuizQuestionListResponse> getQuizWithQuestions(@PathVariable Long quizId) {
+    public ResponseEntity<QuizQuestionListResponse> getQuizWithQuestions(
+            @PathVariable Long quizId) {
 
         QuizQuestionListResponse response = quizService.getQuizWithQuestions(quizId);
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -4,6 +4,7 @@ import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
 import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
 import io.f1.backend.domain.quiz.dto.QuizListPageResponse;
+import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.dto.QuizUpdateRequest;
 
 import jakarta.validation.Valid;
@@ -77,5 +78,13 @@ public class QuizController {
         QuizListPageResponse quizzes = quizService.getQuizzes(title, creator, pageable);
 
         return ResponseEntity.ok().body(quizzes);
+    }
+
+    @GetMapping("/{quizId}")
+    public ResponseEntity<QuizQuestionListResponse> getQuizWithQuestions(@PathVariable Long quizId) {
+
+        QuizQuestionListResponse response = quizService.getQuizWithQuestions(quizId);
+
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -198,8 +198,10 @@ public class QuizService {
     }
 
     public QuizQuestionListResponse getQuizWithQuestions(Long quizId) {
-        Quiz quiz = quizRepository.findById(quizId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+        Quiz quiz =
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         return quizToQuizQuestionListResponse(quiz);
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -1,9 +1,6 @@
 package io.f1.backend.domain.quiz.app;
 
-import static io.f1.backend.domain.quiz.mapper.QuizMapper.pageQuizToPageQuizListResponse;
-import static io.f1.backend.domain.quiz.mapper.QuizMapper.quizCreateRequestToQuiz;
-import static io.f1.backend.domain.quiz.mapper.QuizMapper.quizToQuizCreateResponse;
-import static io.f1.backend.domain.quiz.mapper.QuizMapper.toQuizListPageResponse;
+import static io.f1.backend.domain.quiz.mapper.QuizMapper.*;
 
 import static java.nio.file.Files.deleteIfExists;
 
@@ -14,6 +11,7 @@ import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
 import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
 import io.f1.backend.domain.quiz.dto.QuizListPageResponse;
 import io.f1.backend.domain.quiz.dto.QuizListResponse;
+import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.dto.QuizUpdateRequest;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.dao.UserRepository;
@@ -197,5 +195,12 @@ public class QuizService {
         return quizRepository
                 .findById(quizId)
                 .orElseThrow(() -> new RuntimeException("E404002: 존재하지 않는 퀴즈입니다."));
+    }
+
+    public QuizQuestionListResponse getQuizWithQuestions(Long quizId) {
+        Quiz quiz = quizRepository.findById(quizId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+
+        return quizToQuizQuestionListResponse(quiz);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizQuestionListResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizQuestionListResponse.java
@@ -2,8 +2,14 @@ package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.question.dto.QuestionResponse;
 import io.f1.backend.domain.quiz.entity.QuizType;
+
 import java.util.List;
 
-public record QuizQuestionListResponse(String title, QuizType quizType, Long creatorId, String description, String thumbnailUrl, int numberOfQuestion, List<QuestionResponse> questions) {
-
-}
+public record QuizQuestionListResponse(
+        String title,
+        QuizType quizType,
+        Long creatorId,
+        String description,
+        String thumbnailUrl,
+        int numberOfQuestion,
+        List<QuestionResponse> questions) {}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizQuestionListResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizQuestionListResponse.java
@@ -1,0 +1,9 @@
+package io.f1.backend.domain.quiz.dto;
+
+import io.f1.backend.domain.question.dto.QuestionResponse;
+import io.f1.backend.domain.quiz.entity.QuizType;
+import java.util.List;
+
+public record QuizQuestionListResponse(String title, QuizType quizType, Long creatorId, String description, String thumbnailUrl, int numberOfQuestion, List<QuestionResponse> questions) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -1,12 +1,16 @@
 package io.f1.backend.domain.quiz.mapper;
 
+import io.f1.backend.domain.question.dto.QuestionResponse;
+import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.quiz.dto.QuizCreateRequest;
 import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
 import io.f1.backend.domain.quiz.dto.QuizListPageResponse;
 import io.f1.backend.domain.quiz.dto.QuizListResponse;
+import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.entity.User;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 
 public class QuizMapper {
@@ -55,5 +59,27 @@ public class QuizMapper {
 
     public static Page<QuizListResponse> pageQuizToPageQuizListResponse(Page<Quiz> quizzes) {
         return quizzes.map(QuizMapper::quizToQuizListResponse);
+    }
+
+    public static List<QuestionResponse> questionsToQuestionResponses(List<Question> questions) {
+        return questions.stream()
+            .map(question -> new QuestionResponse(
+                    question.getId(),
+                    question.getTextQuestion().getContent(),
+                    question.getAnswer()
+            ))
+            .toList();
+    }
+
+    public static QuizQuestionListResponse quizToQuizQuestionListResponse(Quiz quiz) {
+        return new QuizQuestionListResponse(
+            quiz.getTitle(),
+            quiz.getQuizType(),
+            quiz.getCreator().getId(),
+            quiz.getDescription(),
+            quiz.getThumbnailUrl(),
+            quiz.getQuestions().size(),
+            questionsToQuestionResponses(quiz.getQuestions())
+        );
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -10,8 +10,9 @@ import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.entity.User;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public class QuizMapper {
 
@@ -63,23 +64,23 @@ public class QuizMapper {
 
     public static List<QuestionResponse> questionsToQuestionResponses(List<Question> questions) {
         return questions.stream()
-            .map(question -> new QuestionResponse(
-                    question.getId(),
-                    question.getTextQuestion().getContent(),
-                    question.getAnswer()
-            ))
-            .toList();
+                .map(
+                        question ->
+                                new QuestionResponse(
+                                        question.getId(),
+                                        question.getTextQuestion().getContent(),
+                                        question.getAnswer()))
+                .toList();
     }
 
     public static QuizQuestionListResponse quizToQuizQuestionListResponse(Quiz quiz) {
         return new QuizQuestionListResponse(
-            quiz.getTitle(),
-            quiz.getQuizType(),
-            quiz.getCreator().getId(),
-            quiz.getDescription(),
-            quiz.getThumbnailUrl(),
-            quiz.getQuestions().size(),
-            questionsToQuestionResponses(quiz.getQuestions())
-        );
+                quiz.getTitle(),
+                quiz.getQuizType(),
+                quiz.getCreator().getId(),
+                quiz.getDescription(),
+                quiz.getThumbnailUrl(),
+                quiz.getQuestions().size(),
+                questionsToQuestionResponses(quiz.getQuestions()));
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #37 

## 🪐 작업 내용
<img width="874" height="746" alt="스크린샷 2025-07-15 오전 10 37 39" src="https://github.com/user-attachments/assets/4a4c832b-5ce6-48ee-855e-07f074a54d7f" />

퀴즈와 문제를 함께 조회해오는 API를 구현했습니다. 

기존 API 명세서에서 questions의 question을 questions의 content로 수정했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] 포스트맨으로 테스트
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?