### PR TITLE
[feat] 커스텀 예외 공통 처리

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoomCreateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoomCreateRequest.java
@@ -11,5 +11,5 @@ public record RoomCreateRequest(
                 @Min(value = 2, message = "방 인원 수는 최소 2명입니다.")
                 @Max(value = 8, message = "방 인원 수는 최대 8명 입니다.")
                 Integer maxUserCount,
-        @NotBlank String password,
+        @NotNull String password,
         @NotNull Boolean locked) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoomCreateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoomCreateRequest.java
@@ -11,5 +11,5 @@ public record RoomCreateRequest(
                 @Min(value = 2, message = "방 인원 수는 최소 2명입니다.")
                 @Max(value = 8, message = "방 인원 수는 최대 8명 입니다.")
                 Integer maxUserCount,
-        @NotNull String password,
+        @NotBlank String password,
         @NotNull Boolean locked) {}

--- a/backend/src/main/java/io/f1/backend/global/exception/CustomException.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/CustomException.java
@@ -1,8 +1,17 @@
 package io.f1.backend.global.exception;
 
+import io.f1.backend.global.exception.errorcode.ErrorCode;
+
 public class CustomException extends RuntimeException {
 
-    public CustomException(String message) {
-        super(message);
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/AuthErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/AuthErrorCode.java
@@ -2,12 +2,12 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-
     UNAUTHORIZED("E401001", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     AUTH_SESSION_NOT_FOUND("E401002", HttpStatus.UNAUTHORIZED, "세션이 존재하지 않습니다. 로그인 후 이용해주세요."),
     AUTH_SESSION_EXPIRED("E401003", HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요."),
@@ -21,5 +21,4 @@ public enum AuthErrorCode implements ErrorCode {
     private final HttpStatus httpStatus;
 
     private final String message;
-
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/AuthErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/AuthErrorCode.java
@@ -1,0 +1,25 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    UNAUTHORIZED("E401001", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    AUTH_SESSION_NOT_FOUND("E401002", HttpStatus.UNAUTHORIZED, "세션이 존재하지 않습니다. 로그인 후 이용해주세요."),
+    AUTH_SESSION_EXPIRED("E401003", HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요."),
+    AUTH_SESSION_LOST("E401004", HttpStatus.UNAUTHORIZED, "세션 정보가 유실되었습니다. 다시 로그인해주세요."),
+    FORBIDDEN("E403001", HttpStatus.FORBIDDEN, "권한이 없습니다."),
+
+    LOGIN_FAILED("E401005", HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
@@ -1,0 +1,20 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    BAD_REQUEST_DATA("E400001", HttpStatus.BAD_REQUEST, "잘못된 요청 데이터입니다."),
+    INVALID_PAGINATION("E400006", HttpStatus.BAD_REQUEST, "page와 size는 1 이상의 정수여야 합니다."),
+    INTERNAL_SERVER_ERROR("E500001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러가 발생했습니다. 관리자에게 문의해주세요.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
@@ -2,15 +2,16 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
-
     BAD_REQUEST_DATA("E400001", HttpStatus.BAD_REQUEST, "잘못된 요청 데이터입니다."),
     INVALID_PAGINATION("E400006", HttpStatus.BAD_REQUEST, "page와 size는 1 이상의 정수여야 합니다."),
-    INTERNAL_SERVER_ERROR("E500001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러가 발생했습니다. 관리자에게 문의해주세요.");
+    INTERNAL_SERVER_ERROR(
+            "E500001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러가 발생했습니다. 관리자에게 문의해주세요.");
 
     private final String code;
 

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
@@ -11,7 +11,8 @@ public enum CommonErrorCode implements ErrorCode {
     BAD_REQUEST_DATA("E400001", HttpStatus.BAD_REQUEST, "잘못된 요청 데이터입니다."),
     INVALID_PAGINATION("E400006", HttpStatus.BAD_REQUEST, "page와 size는 1 이상의 정수여야 합니다."),
     INTERNAL_SERVER_ERROR(
-            "E500001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러가 발생했습니다. 관리자에게 문의해주세요.");
+            "E500001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러가 발생했습니다. 관리자에게 문의해주세요."),
+    INVALID_JSON_FORMAT("E400008", HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다. JSON 문법을 확인해주세요.");
 
     private final String code;
 

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/ErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/ErrorCode.java
@@ -9,5 +9,4 @@ public interface ErrorCode {
     HttpStatus getHttpStatus();
 
     String getMessage();
-
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/ErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/ErrorCode.java
@@ -1,0 +1,13 @@
+package io.f1.backend.global.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String getCode();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuestionErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuestionErrorCode.java
@@ -1,0 +1,19 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionErrorCode implements ErrorCode {
+
+    QUESTION_NOT_FOUND("E404003", HttpStatus.NOT_FOUND, "존재하지 않는 문제입니다.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuestionErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuestionErrorCode.java
@@ -2,12 +2,12 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum QuestionErrorCode implements ErrorCode {
-
     QUESTION_NOT_FOUND("E404003", HttpStatus.NOT_FOUND, "존재하지 않는 문제입니다.");
 
     private final String code;
@@ -15,5 +15,4 @@ public enum QuestionErrorCode implements ErrorCode {
     private final HttpStatus httpStatus;
 
     private final String message;
-
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
@@ -2,12 +2,12 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum QuizErrorCode implements ErrorCode {
-
     FILE_SIZE_TOO_LARGE("E400005", HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
     UNSUPPORTED_MEDIA_TYPE("E415001", HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다."),
     INVALID_FILTER("E400007", HttpStatus.BAD_REQUEST, "title 또는 creator 중 하나만 입력 가능합니다."),
@@ -18,5 +18,4 @@ public enum QuizErrorCode implements ErrorCode {
     private final HttpStatus httpStatus;
 
     private final String message;
-
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
@@ -1,0 +1,22 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuizErrorCode implements ErrorCode {
+
+    FILE_SIZE_TOO_LARGE("E400005", HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
+    UNSUPPORTED_MEDIA_TYPE("E415001", HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다."),
+    INVALID_FILTER("E400007", HttpStatus.BAD_REQUEST, "title 또는 creator 중 하나만 입력 가능합니다."),
+    QUIZ_NOT_FOUND("E404002", HttpStatus.NOT_FOUND, "존재하지 않는 퀴즈입니다.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
@@ -2,12 +2,12 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum RoomErrorCode implements ErrorCode {
-
     ROOM_USER_LIMIT_REACHED("E403002", HttpStatus.FORBIDDEN, "정원이 모두 찼습니다."),
     ROOM_GAME_IN_PROGRESS("E403003", HttpStatus.FORBIDDEN, "게임이 진행 중 입니다."),
     ROOM_NOT_FOUND("E404005", HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
@@ -1,0 +1,21 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoomErrorCode implements ErrorCode {
+
+    ROOM_USER_LIMIT_REACHED("E403002", HttpStatus.FORBIDDEN, "정원이 모두 찼습니다."),
+    ROOM_GAME_IN_PROGRESS("E403003", HttpStatus.FORBIDDEN, "게임이 진행 중 입니다."),
+    ROOM_NOT_FOUND("E404005", HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
+    WRONG_PASSWORD("E401006", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지않습니다.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/UserErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/UserErrorCode.java
@@ -2,12 +2,12 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-
     NICKNAME_EMPTY("E400002", HttpStatus.BAD_REQUEST, "닉네임은 필수 입력입니다."),
     NICKNAME_TOO_LONG("E400003", HttpStatus.BAD_REQUEST, "닉네임은 6글자 이하로 입력해야 합니다."),
     NICKNAME_NOT_ALLOWED("E400004", HttpStatus.BAD_REQUEST, "한글, 영문, 숫자만 입력해주세요."),

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/UserErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/UserErrorCode.java
@@ -1,0 +1,22 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    NICKNAME_EMPTY("E400002", HttpStatus.BAD_REQUEST, "닉네임은 필수 입력입니다."),
+    NICKNAME_TOO_LONG("E400003", HttpStatus.BAD_REQUEST, "닉네임은 6글자 이하로 입력해야 합니다."),
+    NICKNAME_NOT_ALLOWED("E400004", HttpStatus.BAD_REQUEST, "한글, 영문, 숫자만 입력해주세요."),
+    NICKNAME_CONFLICT("E409001", HttpStatus.CONFLICT, "중복된 닉네임입니다."),
+    USER_NOT_FOUND("E404001", HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package io.f1.backend.global.exception.handler;
+
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.CommonErrorCode;
+import io.f1.backend.global.exception.errorcode.ErrorCode;
+import io.f1.backend.global.exception.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        ErrorResponse response = new ErrorResponse(
+            errorCode.getCode(),
+            errorCode.getMessage()
+        );
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        CommonErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+
+        ErrorResponse response = new ErrorResponse(
+            errorCode.getCode(),
+            errorCode.getMessage()
+        );
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        CommonErrorCode code = CommonErrorCode.BAD_REQUEST_DATA;
+
+        String message = e.getBindingResult().getFieldErrors().stream()
+            .map(FieldError::getDefaultMessage)
+            .findFirst()
+            .orElse(code.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+            code.getCode(),
+            message
+        );
+
+        return new ResponseEntity<>(response, code.getHttpStatus());
+
+    }
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import io.f1.backend.global.exception.errorcode.ErrorCode;
 import io.f1.backend.global.exception.response.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -53,7 +54,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e) {
         log.warn("HttpMessageNotReadableException: {}", e.getMessage());
         CommonErrorCode code = CommonErrorCode.INVALID_JSON_FORMAT;
 

--- a/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
@@ -5,17 +5,21 @@ import io.f1.backend.global.exception.errorcode.CommonErrorCode;
 import io.f1.backend.global.exception.errorcode.ErrorCode;
 import io.f1.backend.global.exception.response.ErrorResponse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.warn(e.getMessage());
         ErrorCode errorCode = e.getErrorCode();
 
         ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
@@ -24,6 +28,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.warn("handleException: {}", e.getMessage());
         CommonErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
 
         ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
@@ -33,7 +38,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException e) {
-
+        log.warn("MethodArgumentNotValidException: {}", e.getMessage());
         CommonErrorCode code = CommonErrorCode.BAD_REQUEST_DATA;
 
         String message =
@@ -43,6 +48,16 @@ public class GlobalExceptionHandler {
                         .orElse(code.getMessage());
 
         ErrorResponse response = new ErrorResponse(code.getCode(), message);
+
+        return new ResponseEntity<>(response, code.getHttpStatus());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadableException: {}", e.getMessage());
+        CommonErrorCode code = CommonErrorCode.INVALID_JSON_FORMAT;
+
+        ErrorResponse response = new ErrorResponse(code.getCode(), code.getMessage());
 
         return new ResponseEntity<>(response, code.getHttpStatus());
     }

--- a/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.CommonErrorCode;
 import io.f1.backend.global.exception.errorcode.ErrorCode;
 import io.f1.backend.global.exception.response.ErrorResponse;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,10 +18,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
 
-        ErrorResponse response = new ErrorResponse(
-            errorCode.getCode(),
-            errorCode.getMessage()
-        );
+        ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
@@ -28,29 +26,24 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         CommonErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
 
-        ErrorResponse response = new ErrorResponse(
-            errorCode.getCode(),
-            errorCode.getMessage()
-        );
+        ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
 
         CommonErrorCode code = CommonErrorCode.BAD_REQUEST_DATA;
 
-        String message = e.getBindingResult().getFieldErrors().stream()
-            .map(FieldError::getDefaultMessage)
-            .findFirst()
-            .orElse(code.getMessage());
+        String message =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(FieldError::getDefaultMessage)
+                        .findFirst()
+                        .orElse(code.getMessage());
 
-        ErrorResponse response = new ErrorResponse(
-            code.getCode(),
-            message
-        );
+        ErrorResponse response = new ErrorResponse(code.getCode(), message);
 
         return new ResponseEntity<>(response, code.getHttpStatus());
-
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/response/ErrorResponse.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/response/ErrorResponse.java
@@ -1,0 +1,13 @@
+package io.f1.backend.global.exception.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/response/ErrorResponse.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/response/ErrorResponse.java
@@ -9,5 +9,4 @@ public class ErrorResponse {
 
     private final String code;
     private final String message;
-
 }


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #35 

## 🪐 작업 내용

### 에러코드
에러코드는 공통 에러처리와 도메인별로 Enum클래스를 나누어 놓았습니다. 에러코드가 많지 않은 경우, 하나에 몰아넣고 주석으로 구분하는 경우가 많은데, 분리하는 경우가 각 도메인별 책임분리도 되고,
```
Room room =
                roomRepository
                        .findRoom(request.roomId())
                        .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
```
위 코드와 같이 유지보수나 가독성에 도움이 된다고 판단하였습니다.

### 글로벌 예외 처리 로직 - GlobalHandlerException
- **handleCustomException**
→ CustomException 을 잡아서, 예외에 담긴 커스텀 에러코드와 메시지, HTTP 상태코드를 사용해 응답을 만들어서 내려줍니다.
즉, 직접 정의한 비즈니스 예외 처리용입니다.
<img width="1502" height="173" alt="스크린샷 2025-07-15 오전 11 19 44" src="https://github.com/user-attachments/assets/29aeca7c-810f-49e1-bc0a-613d8b7eb471" />

- **handleException**
→ Exception 클래스(모든 예외의 최상위)를 잡아서, 정의하지 않은 모든 예외에 대해 500 서버 에러 응답을 내려줍니다.
즉, 의도하지 않은 에러, 예상하지 못한 에러를 위한 보험입니다.
<img width="1508" height="172" alt="스크린샷 2025-07-15 오전 11 55 26" src="https://github.com/user-attachments/assets/9ba5092d-4b6d-4d82-86cc-dcf900bb1887" />

- **handleMethodArgumentNotValidException**
→ @Valid 검증 실패 시 발생하는 MethodArgumentNotValidException 을 잡아, 필드별 에러 메시지 중 첫 번째를 뽑아 BAD_REQUEST 코드와 함께 반환합니다.


<img width="1509" height="174" alt="스크린샷 2025-07-15 오전 11 19 31" src="https://github.com/user-attachments/assets/c7a54d5d-f917-4fef-a1ec-a4f7dfe7cdb1" />


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?