### PR TITLE
[feat] 문제 수정, 삭제 API 구현

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
@@ -1,0 +1,35 @@
+package io.f1.backend.domain.question.api;
+
+import io.f1.backend.domain.question.app.QuestionService;
+import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/questions")
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @PutMapping("/{questionId}")
+    public ResponseEntity<Void> updateQuestion(@PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
+        questionService.updateQuestion(questionId, request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<Void> deleteQuestion(@PathVariable Long questionId) {
+        questionService.deleteQuestion(questionId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
@@ -21,13 +21,14 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @PutMapping("/{questionId}")
-    public ResponseEntity<Void> updateQuestion(@PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
+    public ResponseEntity<Void> updateQuestion(
+            @PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
 
-        if(request.content()!=null) {
+        if (request.content() != null) {
             questionService.updateQuestionContent(questionId, request.content());
         }
 
-        if(request.content()!=null) {
+        if (request.content() != null) {
             questionService.updateQuestionAnswer(questionId, request.answer());
         }
 

--- a/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
@@ -2,7 +2,9 @@ package io.f1.backend.domain.question.api;
 
 import io.f1.backend.domain.question.app.QuestionService;
 import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,7 +21,8 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @PutMapping("/{questionId}")
-    public ResponseEntity<Void> updateQuestion(@PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
+    public ResponseEntity<Void> updateQuestion(
+            @PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
         questionService.updateQuestion(questionId, request);
 
         return ResponseEntity.noContent().build();
@@ -31,5 +34,4 @@ public class QuestionController {
 
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
@@ -21,9 +21,15 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @PutMapping("/{questionId}")
-    public ResponseEntity<Void> updateQuestion(
-            @PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
-        questionService.updateQuestion(questionId, request);
+    public ResponseEntity<Void> updateQuestion(@PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
+
+        if(request.content()!=null) {
+            questionService.updateQuestionContent(questionId, request.content());
+        }
+
+        if(request.content()!=null) {
+            questionService.updateQuestionAnswer(questionId, request.answer());
+        }
 
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -38,7 +38,9 @@ public class QuestionService {
     }
 
     @Transactional
-    public void updateQuestion(Long questionId, QuestionUpdateRequest request) {
+    public void updateQuestionContent(Long questionId, String content) {
+
+        validateContent(content);
 
         Question question =
                 questionRepository
@@ -46,16 +48,19 @@ public class QuestionService {
                         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
 
         TextQuestion textQuestion = question.getTextQuestion();
+        textQuestion.changeContent(content);
+    }
 
-        if (request.content() != null) {
-            validateContent(request.content());
-            textQuestion.changeContent(request.content());
-        }
+    @Transactional
+    public void updateQuestionAnswer(Long questionId, String answer) {
 
-        if (request.answer() != null) {
-            validateAnswer(request.answer());
-            question.changeAnswer(request.answer());
-        }
+        validateAnswer(answer);
+
+        Question question = questionRepository.findById(questionId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+
+        question.changeAnswer(answer);
+
     }
 
     @Transactional

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -11,11 +11,12 @@ import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -39,41 +40,43 @@ public class QuestionService {
     @Transactional
     public void updateQuestion(Long questionId, QuestionUpdateRequest request) {
 
-        Question question = questionRepository.findById(questionId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+        Question question =
+                questionRepository
+                        .findById(questionId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
 
         TextQuestion textQuestion = question.getTextQuestion();
 
-        if(request.content() != null) {
+        if (request.content() != null) {
             validateContent(request.content());
             textQuestion.changeContent(request.content());
         }
 
-        if(request.answer() != null) {
+        if (request.answer() != null) {
             validateAnswer(request.answer());
             question.changeAnswer(request.answer());
         }
-
     }
 
     @Transactional
     public void deleteQuestion(Long questionId) {
 
-        Question question = questionRepository.findById(questionId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+        Question question =
+                questionRepository
+                        .findById(questionId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
 
         questionRepository.delete(question);
-
     }
 
     private void validateAnswer(String answer) {
-        if(answer.trim().length() < 5 || answer.trim().length() > 30) {
+        if (answer.trim().length() < 5 || answer.trim().length() > 30) {
             throw new IllegalArgumentException("정답은 1자 이상 30자 이하로 입력해주세요.");
         }
     }
 
     private void validateContent(String content) {
-        if(content.trim().length() < 5 || content.trim().length() > 30) {
+        if (content.trim().length() < 5 || content.trim().length() > 30) {
             throw new IllegalArgumentException("문제는 5자 이상 30자 이하로 입력해주세요.");
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -6,7 +6,6 @@ import static io.f1.backend.domain.question.mapper.TextQuestionMapper.questionRe
 import io.f1.backend.domain.question.dao.QuestionRepository;
 import io.f1.backend.domain.question.dao.TextQuestionRepository;
 import io.f1.backend.domain.question.dto.QuestionRequest;
-import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
 import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.quiz.entity.Quiz;
@@ -56,11 +55,12 @@ public class QuestionService {
 
         validateAnswer(answer);
 
-        Question question = questionRepository.findById(questionId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+        Question question =
+                questionRepository
+                        .findById(questionId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
 
         question.changeAnswer(answer);
-
     }
 
     @Transactional

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -6,10 +6,12 @@ import static io.f1.backend.domain.question.mapper.TextQuestionMapper.questionRe
 import io.f1.backend.domain.question.dao.QuestionRepository;
 import io.f1.backend.domain.question.dao.TextQuestionRepository;
 import io.f1.backend.domain.question.dto.QuestionRequest;
+import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
 import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -32,5 +34,47 @@ public class QuestionService {
         TextQuestion textQuestion = questionRequestToTextQuestion(question, request.getContent());
         textQuestionRepository.save(textQuestion);
         question.addTextQuestion(textQuestion);
+    }
+
+    @Transactional
+    public void updateQuestion(Long questionId, QuestionUpdateRequest request) {
+
+        Question question = questionRepository.findById(questionId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+
+        TextQuestion textQuestion = question.getTextQuestion();
+
+        if(request.content() != null) {
+            validateContent(request.content());
+            textQuestion.changeContent(request.content());
+        }
+
+        if(request.answer() != null) {
+            validateAnswer(request.answer());
+            question.changeAnswer(request.answer());
+        }
+
+    }
+
+    @Transactional
+    public void deleteQuestion(Long questionId) {
+
+        Question question = questionRepository.findById(questionId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+
+        questionRepository.delete(question);
+
+    }
+
+    private void validateAnswer(String answer) {
+        if(answer.trim().length() < 5 || answer.trim().length() > 30) {
+            throw new IllegalArgumentException("정답은 1자 이상 30자 이하로 입력해주세요.");
+        }
+    }
+
+    private void validateContent(String content) {
+        if(content.trim().length() < 5 || content.trim().length() > 30) {
+            throw new IllegalArgumentException("문제는 5자 이상 30자 이하로 입력해주세요.");
+        }
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
@@ -1,5 +1,6 @@
 package io.f1.backend.domain.question.dto;
 
+import io.f1.backend.global.validation.TrimmedSize;
 import jakarta.validation.constraints.NotBlank;
 
 import lombok.AccessLevel;
@@ -10,9 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionRequest {
 
+    @TrimmedSize(min=5, max=30)
     @NotBlank(message = "문제를 입력해주세요.")
     private String content;
 
+    @TrimmedSize(min=1, max=30)
     @NotBlank(message = "정답을 입력해주세요.")
     private String answer;
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionRequest.java
@@ -1,6 +1,7 @@
 package io.f1.backend.domain.question.dto;
 
 import io.f1.backend.global.validation.TrimmedSize;
+
 import jakarta.validation.constraints.NotBlank;
 
 import lombok.AccessLevel;
@@ -11,11 +12,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionRequest {
 
-    @TrimmedSize(min=5, max=30)
+    @TrimmedSize(min = 5, max = 30)
     @NotBlank(message = "문제를 입력해주세요.")
     private String content;
 
-    @TrimmedSize(min=1, max=30)
+    @TrimmedSize(min = 1, max = 30)
     @NotBlank(message = "정답을 입력해주세요.")
     private String answer;
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
@@ -1,5 +1,3 @@
 package io.f1.backend.domain.question.dto;
 
-public record QuestionUpdateRequest(String content, String answer) {
-
-}
+public record QuestionUpdateRequest(String content, String answer) {}

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
@@ -1,0 +1,5 @@
+package io.f1.backend.domain.question.dto;
+
+public record QuestionUpdateRequest(String content, String answer) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/Question.java
@@ -45,4 +45,8 @@ public class Question extends BaseEntity {
     public void addTextQuestion(TextQuestion textQuestion) {
         this.textQuestion = textQuestion;
     }
+
+    public void changeAnswer(String answer) {
+        this.answer = answer;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/entity/TextQuestion.java
@@ -32,4 +32,8 @@ public class TextQuestion {
         this.question = question;
         this.content = content;
     }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -61,7 +61,17 @@ public class QuizController {
             @RequestPart QuizUpdateRequest request)
             throws IOException {
 
-        quizService.updateQuiz(quizId, thumbnailFile, request);
+        if (request.title() != null) {
+            quizService.updateQuizTitle(quizId, request.title());
+        }
+
+        if(request.description()!=null) {
+            quizService.updateQuizDesc(quizId, request.description());
+        }
+
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            quizService.updateThumbnail(quizId, thumbnailFile);
+        }
 
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -65,7 +65,7 @@ public class QuizController {
             quizService.updateQuizTitle(quizId, request.title());
         }
 
-        if(request.description()!=null) {
+        if (request.description() != null) {
             quizService.updateQuizDesc(quizId, request.description());
         }
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -12,7 +12,6 @@ import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
 import io.f1.backend.domain.quiz.dto.QuizListPageResponse;
 import io.f1.backend.domain.quiz.dto.QuizListResponse;
 import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
-import io.f1.backend.domain.quiz.dto.QuizUpdateRequest;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.entity.User;
@@ -125,9 +124,9 @@ public class QuizService {
     @Transactional
     public void updateQuizTitle(Long quizId, String title) {
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         validateTitle(title);
         quiz.changeTitle(title);
@@ -137,22 +136,21 @@ public class QuizService {
     public void updateQuizDesc(Long quizId, String description) {
 
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         validateDesc(description);
         quiz.changeDescription(description);
-
     }
 
     @Transactional
     public void updateThumbnail(Long quizId, MultipartFile thumbnailFile) throws IOException {
 
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         validateImageFile(thumbnailFile);
         String newThumbnailPath = convertToThumbnailPath(thumbnailFile);

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -132,10 +132,12 @@ public class QuizService {
                         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         if (request.title() != null) {
+            validateTitle(request.title());
             quiz.changeTitle(request.title());
         }
 
         if (request.description() != null) {
+            validateDesc(request.description());
             quiz.changeDescription(request.description());
         }
 
@@ -145,6 +147,18 @@ public class QuizService {
 
             deleteThumbnailFile(quiz.getThumbnailUrl());
             quiz.changeThumbnailUrl(newThumbnailPath);
+        }
+    }
+
+    private void validateDesc(String desc) {
+        if( desc.trim().length() < 10 || desc.trim().length() > 50) {
+            throw new IllegalArgumentException("설명은 10자 이상 50자 이하로 입력해주세요.");
+        }
+    }
+
+    private void validateTitle(String title) {
+        if (title.trim().length() < 2 || title.trim().length() > 30) {
+            throw new IllegalArgumentException("제목은 2자 이상 30자 이하로 입력해주세요.");
         }
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -151,7 +151,7 @@ public class QuizService {
     }
 
     private void validateDesc(String desc) {
-        if( desc.trim().length() < 10 || desc.trim().length() > 50) {
+        if (desc.trim().length() < 10 || desc.trim().length() > 50) {
             throw new IllegalArgumentException("설명은 10자 이상 50자 이하로 입력해주세요.");
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -123,31 +123,42 @@ public class QuizService {
     }
 
     @Transactional
-    public void updateQuiz(Long quizId, MultipartFile thumbnailFile, QuizUpdateRequest request)
-            throws IOException {
+    public void updateQuizTitle(Long quizId, String title) {
+        Quiz quiz =
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+
+        validateTitle(title);
+        quiz.changeTitle(title);
+    }
+
+    @Transactional
+    public void updateQuizDesc(Long quizId, String description) {
 
         Quiz quiz =
-                quizRepository
-                        .findById(quizId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
-        if (request.title() != null) {
-            validateTitle(request.title());
-            quiz.changeTitle(request.title());
-        }
+        validateDesc(description);
+        quiz.changeDescription(description);
 
-        if (request.description() != null) {
-            validateDesc(request.description());
-            quiz.changeDescription(request.description());
-        }
+    }
 
-        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
-            validateImageFile(thumbnailFile);
-            String newThumbnailPath = convertToThumbnailPath(thumbnailFile);
+    @Transactional
+    public void updateThumbnail(Long quizId, MultipartFile thumbnailFile) throws IOException {
 
-            deleteThumbnailFile(quiz.getThumbnailUrl());
-            quiz.changeThumbnailUrl(newThumbnailPath);
-        }
+        Quiz quiz =
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+
+        validateImageFile(thumbnailFile);
+        String newThumbnailPath = convertToThumbnailPath(thumbnailFile);
+
+        deleteThumbnailFile(quiz.getThumbnailUrl());
+        quiz.changeThumbnailUrl(newThumbnailPath);
     }
 
     private void validateDesc(String desc) {

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
@@ -3,6 +3,7 @@ package io.f1.backend.domain.quiz.dto;
 import io.f1.backend.domain.question.dto.QuestionRequest;
 import io.f1.backend.domain.quiz.entity.QuizType;
 
+import io.f1.backend.global.validation.TrimmedSize;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -17,12 +18,14 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuizCreateRequest {
 
+    @TrimmedSize(min = 2, max = 30)
     @NotBlank(message = "퀴즈 제목을 설정해주세요.")
     private String title;
 
     @NotNull(message = "퀴즈 종류를 선택해주세요.")
     private QuizType quizType;
 
+    @TrimmedSize(min = 10, max = 50)
     @NotBlank(message = "퀴즈 설명을 적어주세요.")
     private String description;
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizCreateRequest.java
@@ -2,8 +2,8 @@ package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.question.dto.QuestionRequest;
 import io.f1.backend.domain.quiz.entity.QuizType;
-
 import io.f1.backend.global.validation.TrimmedSize;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                                                 "/oauth2/**",
                                                 "/signup",
                                                 "/css/**",
-                                                "/js/**", "/**")
+                                                "/js/**")
                                         .permitAll()
                                         .requestMatchers("/ws/**")
                                         .authenticated()

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                                                 "/oauth2/**",
                                                 "/signup",
                                                 "/css/**",
-                                                "/js/**")
+                                                "/js/**", "/**")
                                         .permitAll()
                                         .requestMatchers("/ws/**")
                                         .authenticated()

--- a/backend/src/main/java/io/f1/backend/global/validation/TrimmedSize.java
+++ b/backend/src/main/java/io/f1/backend/global/validation/TrimmedSize.java
@@ -2,20 +2,22 @@ package io.f1.backend.global.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
+
 import java.lang.annotation.*;
 
 @Documented
 @Constraint(validatedBy = TrimmedSizeValidator.class)
-@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TrimmedSize {
 
     String message() default "공백 제외 길이가 {min}자 이상 {min}자 이하여야 합니다.";
 
     int min() default 0;
+
     int max() default 50;
 
     Class<?>[] groups() default {};
-    Class<? extends Payload>[] payload() default {};
 
+    Class<? extends Payload>[] payload() default {};
 }

--- a/backend/src/main/java/io/f1/backend/global/validation/TrimmedSize.java
+++ b/backend/src/main/java/io/f1/backend/global/validation/TrimmedSize.java
@@ -1,0 +1,21 @@
+package io.f1.backend.global.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = TrimmedSizeValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrimmedSize {
+
+    String message() default "공백 제외 길이가 {min}자 이상 {min}자 이하여야 합니다.";
+
+    int min() default 0;
+    int max() default 50;
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/backend/src/main/java/io/f1/backend/global/validation/TrimmedSizeValidator.java
+++ b/backend/src/main/java/io/f1/backend/global/validation/TrimmedSizeValidator.java
@@ -16,7 +16,7 @@ public class TrimmedSizeValidator implements ConstraintValidator<TrimmedSize, St
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        if( value == null ) return true;
+        if (value == null) return true;
 
         String trimmed = value.trim();
         int length = trimmed.length();

--- a/backend/src/main/java/io/f1/backend/global/validation/TrimmedSizeValidator.java
+++ b/backend/src/main/java/io/f1/backend/global/validation/TrimmedSizeValidator.java
@@ -1,0 +1,26 @@
+package io.f1.backend.global.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class TrimmedSizeValidator implements ConstraintValidator<TrimmedSize, String> {
+
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(TrimmedSize constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if( value == null ) return true;
+
+        String trimmed = value.trim();
+        int length = trimmed.length();
+
+        return length >= min && length <= max;
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #43 

## 🪐 작업 내용

### 1. Question 수정, 삭제 API 구현
문제 수정, 삭제 API를 구현했습니다. 포스트맨으로 정상 동작하는 것 확인했습니다. 

```json
{
  "content": "새 문제",
  "answer": null 
}
```

- 위와 같이 변경되지 않은 값은 null로 오고, 변경된 값이면 변경된 값을 담아서 요청으로 들어옵니다. 
- 기존 API 명세서에서 `question` -> `content`로 변경했습니다.

### 2. 길이 제한 설정

수정할 때 빈 문자열을 보내올 수도 있겠다 싶어 퀴즈 제목, 설명 / 퀴즈 문제, 정답도 글자 수에 제한을 둬야겠다고 생각했습니다. 

`QuizCreateRequest` 와 `QuestionCreateRequest`에서 `@NotBlank`와 `@Size`로 유효성 검사를 진행합니다. 

근데, 이랬을 경우 수정 때는 변경되지 않은 값은 `null`로 들어올 수 있기 때문에 `DTO`차원에서 유효성 검사를 해줄 순 없어 서비스에서 글자 수를 검사합니다. 

- 근데 또..!  서비스에서 글자수만 검사할 경우, `"     "` 이러한 문자열이 들어올 수 있다고 생각했습니다. 
- `@NotBlank` 검사를 해줄 수 없기 때문에 서비스에서 `trim()`을 해줘야 하는데 그럼 **글자 수 비교가 생성할 때와 수정할 때 기준이 좀 달라지게 됩니다. (공백 포함 vs 공백 제외)**

### 3. TrimmedSize 어노테이션 추가 

그래서 `@TrimmedSize`라는 어노테이션을 추가했고, `ConstraintValidator`를 구현하여 Validator를 정의했습니다. 

이에 따라 퀴즈의 제목, 설명 / 퀴즈의 문제, 정답 글자 수 제한은 다음과 같습니다. 

- 퀴즈 제목 : 공백 제외 2자 ~ 30자
- 퀴즈 설명 : 공백 제외 10자 ~ 50자
- 문제 : 공백 제외 5자 ~ 30자
- 정답 : 공백 제외 1자 ~ 30자

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] 포스트맨 테스트 했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?