### PR TITLE
[feat] 방 입/퇴장 동시성 구현 및 로직 변경

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/api/RoomController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/api/RoomController.java
@@ -31,10 +31,10 @@ public class RoomController {
         return roomService.saveRoom(request);
     }
 
-    @PostMapping("/validation")
+    @PostMapping("/enterRoom")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void validateRoom(@RequestBody @Valid RoomValidationRequest request) {
-        roomService.validateRoom(request);
+        roomService.enterRoom(request);
     }
 
     @GetMapping

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -31,17 +31,13 @@ import io.f1.backend.domain.game.model.RoomState;
 import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
-
-import lombok.RequiredArgsConstructor;
-
-import org.hibernate.boot.model.naming.IllegalIdentifierException;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -93,7 +89,7 @@ public class RoomService {
             throw new IllegalArgumentException("401 비밀번호가 일치하지 않습니다.");
         }
 
-        room.getUserIdSessionMap().put(getCurrentUserId(), null);
+        room.getUserIdSessionMap().put(getCurrentUserId(), "");
     }
 
     public RoomInitialData initializeRoomSocket(Long roomId, String sessionId) {

--- a/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
@@ -27,7 +27,7 @@ public class Room {
 
     private Map<String, Player> playerSessionMap = new ConcurrentHashMap<>();
 
-    private Map<Long,String> userIdSessionMap = new ConcurrentHashMap<>();
+    private Map<Long, String> userIdSessionMap = new ConcurrentHashMap<>();
 
     private final LocalDateTime createdAt = LocalDateTime.now();
 
@@ -36,7 +36,6 @@ public class Room {
         this.roomSetting = roomSetting;
         this.gameSetting = gameSetting;
         this.host = host;
-
     }
 
     public void updateHost(Player nextHost) {

--- a/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
@@ -27,6 +27,8 @@ public class Room {
 
     private Map<String, Player> playerSessionMap = new ConcurrentHashMap<>();
 
+    private Map<Long,String> userIdSessionMap = new ConcurrentHashMap<>();
+
     private final LocalDateTime createdAt = LocalDateTime.now();
 
     public Room(Long id, RoomSetting roomSetting, GameSetting gameSetting, Player host) {
@@ -34,6 +36,7 @@ public class Room {
         this.roomSetting = roomSetting;
         this.gameSetting = gameSetting;
         this.host = host;
+
     }
 
     public void updateHost(Player nextHost) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
@@ -20,12 +20,12 @@ public class GameSocketController {
     private final MessageSender messageSender;
     private final RoomService roomService;
 
-    @MessageMapping("/room/enter/{roomId}")
-    public void roomEnter(@DestinationVariable Long roomId, Message<?> message) {
+    @MessageMapping("/room/initializeRoomSocket/{roomId}")
+    public void initializeRoomSocket(@DestinationVariable Long roomId, Message<?> message) {
 
         String websocketSessionId = getSessionId(message);
 
-        RoomInitialData roomInitialData = roomService.enterRoom(roomId, websocketSessionId);
+        RoomInitialData roomInitialData = roomService.initializeRoomSocket(roomId, websocketSessionId);
         String destination = roomInitialData.destination();
 
         messageSender.send(

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
@@ -25,7 +25,8 @@ public class GameSocketController {
 
         String websocketSessionId = getSessionId(message);
 
-        RoomInitialData roomInitialData = roomService.initializeRoomSocket(roomId, websocketSessionId);
+        RoomInitialData roomInitialData =
+                roomService.initializeRoomSocket(roomId, websocketSessionId);
         String destination = roomInitialData.destination();
 
         messageSender.send(

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -1,0 +1,181 @@
+package io.f1.backend.domain.game.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import io.f1.backend.domain.game.dto.request.RoomValidationRequest;
+import io.f1.backend.domain.game.model.GameSetting;
+import io.f1.backend.domain.game.model.Player;
+import io.f1.backend.domain.game.model.Room;
+import io.f1.backend.domain.game.model.RoomSetting;
+import io.f1.backend.domain.game.store.RoomRepository;
+import io.f1.backend.domain.quiz.app.QuizService;
+import io.f1.backend.domain.user.entity.User;
+import io.f1.backend.global.util.SecurityUtils;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class RoomServiceTests {
+
+    private RoomService roomService;
+
+    @Mock
+    private RoomRepository roomRepository;
+    @Mock
+    private QuizService quizService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+
+    @BeforeEach
+    void setUp(){
+        MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
+        roomService = new RoomService(quizService, roomRepository, eventPublisher);
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void afterEach() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("enterRoom_동시성_테스트")
+    void enterRoom_synchronized() throws Exception {
+        Long roomId = 1L;
+        Long quizId = 1L;
+        Long playerId = 1L;
+        String password = "123";
+
+        RoomSetting roomSetting = new RoomSetting("방제목", 5, true, password);
+        GameSetting gameSetting = new GameSetting(quizId, 10, 60);
+        Player host = new Player(playerId, "닉네임");
+
+        Room room = new Room(roomId, roomSetting, gameSetting, host);
+
+        when(roomRepository.findRoom(roomId)).thenReturn(Optional.of(room));
+
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        RoomValidationRequest roomValidationRequest = new RoomValidationRequest(roomId, password);
+        for (int i = 1; i <= threadCount; i++) {
+            Long userId = i + 1L;
+            String provider = "provider +" + i;
+            String providerId = "providerId" + i;
+            LocalDateTime lastLogin = LocalDateTime.now();
+            executorService.submit(() -> {
+                try {
+                    User user = User.builder()
+                        .provider(provider)
+                        .provider(providerId).lastLogin(lastLogin).build();
+
+                    user.setId(userId);
+
+                    SecurityUtils.setAuthentication(user);
+
+                    roomService.enterRoom(roomValidationRequest);
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+        assertThat(room.getUserIdSessionMap()).hasSize(room.getRoomSetting().maxUserCount());
+    }
+
+
+    @Test
+    @DisplayName("exitRoom_동시성_테스트")
+    void exitRoom_synchronized() throws Exception {
+        Long roomId = 1L;
+        Long quizId = 1L;
+        int threadCount = 10;
+
+        String password = "123";
+
+        RoomSetting roomSetting = new RoomSetting("방제목", 5, true, password);
+        GameSetting gameSetting = new GameSetting(quizId, 10, 60);
+
+        List<Player> players = new ArrayList<>();
+        for (int i = 1; i <=threadCount; i++) {
+            Long id = i + 1L;
+            String nickname = "nickname " + i;
+
+            Player player = new Player(id, nickname);
+            players.add(player);
+
+        }
+        Player host = players.getFirst();
+        Room room = new Room(roomId, roomSetting, gameSetting, host);
+
+        for (int i = 1; i <=threadCount; i++) {
+            String sessionId = "sessionId" + i;
+            Player player = players.get(i - 1);
+            room.getPlayerSessionMap().put(sessionId,player);
+            room.getUserIdSessionMap().put(player.getId(),sessionId);
+        }
+
+        log.info("room.getPlayerSessionMap().size() = {}", room.getPlayerSessionMap().size());
+
+        when(roomRepository.findRoom(roomId)).thenReturn(Optional.of(room));
+        doNothing().when(roomRepository).removeRoom(roomId);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        for (int i = 1; i <= threadCount; i++) {
+            Long userId = i + 1L;
+            String sessionId = "sessionId" + i;
+            String provider = "provider +" + i;
+            String providerId = "providerId" + i;
+            LocalDateTime lastLogin = LocalDateTime.now();
+            executorService.submit(() -> {
+                try {
+                    User user = User.builder()
+                        .provider(provider)
+                        .provider(providerId).lastLogin(lastLogin).build();
+                    user.setId(userId);
+                    SecurityUtils.setAuthentication(user);
+
+                    log.info("userId = {}", userId);
+                    log.info("room.getHost().getId() = {}", room.getHost().getId());
+                    roomService.exitRoom(roomId, sessionId);
+                } catch (Exception e) {
+                     e.printStackTrace();
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+        assertThat(room.getUserIdSessionMap()).hasSize(1);
+    }
+
+
+
+}

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -13,14 +13,9 @@ import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.util.SecurityUtils;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,22 +27,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 class RoomServiceTests {
 
     private RoomService roomService;
 
-    @Mock
-    private RoomRepository roomRepository;
-    @Mock
-    private QuizService quizService;
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
-
+    @Mock private RoomRepository roomRepository;
+    @Mock private QuizService quizService;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
         roomService = new RoomService(quizService, roomRepository, eventPublisher);
 
@@ -84,29 +83,32 @@ class RoomServiceTests {
             String provider = "provider +" + i;
             String providerId = "providerId" + i;
             LocalDateTime lastLogin = LocalDateTime.now();
-            executorService.submit(() -> {
-                try {
-                    User user = User.builder()
-                        .provider(provider)
-                        .provider(providerId).lastLogin(lastLogin).build();
+            executorService.submit(
+                    () -> {
+                        try {
+                            User user =
+                                    User.builder()
+                                            .provider(provider)
+                                            .provider(providerId)
+                                            .lastLogin(lastLogin)
+                                            .build();
 
-                    user.setId(userId);
+                            user.setId(userId);
 
-                    SecurityUtils.setAuthentication(user);
+                            SecurityUtils.setAuthentication(user);
 
-                    roomService.enterRoom(roomValidationRequest);
-                } catch (Exception e) {
-                    //e.printStackTrace();
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    countDownLatch.countDown();
-                }
-            });
+                            roomService.enterRoom(roomValidationRequest);
+                        } catch (Exception e) {
+                            // e.printStackTrace();
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            countDownLatch.countDown();
+                        }
+                    });
         }
         countDownLatch.await();
         assertThat(room.getUserIdSessionMap()).hasSize(room.getRoomSetting().maxUserCount());
     }
-
 
     @Test
     @DisplayName("exitRoom_동시성_테스트")
@@ -121,22 +123,21 @@ class RoomServiceTests {
         GameSetting gameSetting = new GameSetting(quizId, 10, 60);
 
         List<Player> players = new ArrayList<>();
-        for (int i = 1; i <=threadCount; i++) {
+        for (int i = 1; i <= threadCount; i++) {
             Long id = i + 1L;
             String nickname = "nickname " + i;
 
             Player player = new Player(id, nickname);
             players.add(player);
-
         }
         Player host = players.getFirst();
         Room room = new Room(roomId, roomSetting, gameSetting, host);
 
-        for (int i = 1; i <=threadCount; i++) {
+        for (int i = 1; i <= threadCount; i++) {
             String sessionId = "sessionId" + i;
             Player player = players.get(i - 1);
-            room.getPlayerSessionMap().put(sessionId,player);
-            room.getUserIdSessionMap().put(player.getId(),sessionId);
+            room.getPlayerSessionMap().put(sessionId, player);
+            room.getUserIdSessionMap().put(player.getId(), sessionId);
         }
 
         log.info("room.getPlayerSessionMap().size() = {}", room.getPlayerSessionMap().size());
@@ -153,29 +154,30 @@ class RoomServiceTests {
             String provider = "provider +" + i;
             String providerId = "providerId" + i;
             LocalDateTime lastLogin = LocalDateTime.now();
-            executorService.submit(() -> {
-                try {
-                    User user = User.builder()
-                        .provider(provider)
-                        .provider(providerId).lastLogin(lastLogin).build();
-                    user.setId(userId);
-                    SecurityUtils.setAuthentication(user);
+            executorService.submit(
+                    () -> {
+                        try {
+                            User user =
+                                    User.builder()
+                                            .provider(provider)
+                                            .provider(providerId)
+                                            .lastLogin(lastLogin)
+                                            .build();
+                            user.setId(userId);
+                            SecurityUtils.setAuthentication(user);
 
-                    log.info("userId = {}", userId);
-                    log.info("room.getHost().getId() = {}", room.getHost().getId());
-                    roomService.exitRoom(roomId, sessionId);
-                } catch (Exception e) {
-                     e.printStackTrace();
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    countDownLatch.countDown();
-                }
-            });
+                            log.info("userId = {}", userId);
+                            log.info("room.getHost().getId() = {}", room.getHost().getId());
+                            roomService.exitRoom(roomId, sessionId);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            countDownLatch.countDown();
+                        }
+                    });
         }
         countDownLatch.await();
         assertThat(room.getUserIdSessionMap()).hasSize(1);
     }
-
-
-
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #21 

## 🪐 작업 내용
- 입, 퇴장 `synchronized` 적용 
- 테스트 완료 
#### 입장 동시서 적용 전 테스트 실패 
<img width="228" height="88" alt="image" src="https://github.com/user-attachments/assets/9315c08c-e631-43ba-a3f3-5d585e18380a" />

#### 입장 동시성 적용 후 테스트 성공
<img width="397" height="66" alt="image" src="https://github.com/user-attachments/assets/1ad446a1-94d9-4381-baa6-5b2af77e8a09" />

#### 퇴장 동시성 적용 전 테스트 실패 
<img width="1030" height="188" alt="image" src="https://github.com/user-attachments/assets/a0c7949c-217a-4214-895e-0d40df01172f" />

#### 퇴장 동시성 적용 후 테스트 성공
<img width="808" height="91" alt="image" src="https://github.com/user-attachments/assets/0313a519-8239-4273-aa83-1c0c5962fe2a" />


- 입장과 validation 체크를 한번에 하도록 로직 변경(RoomService - enterRoom) 
- 이때 방장은 enterRoom을 실행하지 않음.(방생서 후에 바로 웹소켓 연결-구독-요청) 
-  room.getUserIdSessionMap().put(host.id,PENDING_SESSION_ID); 방 생성시 방장은 Map 에 추가됨
- 웹소켓 연결 시 세션 id값을 저장하고, 응답을 내려줌
 ```
   return new RoomInitialData(
            getDestination(roomId),
            roomSettingResponse,
            gameSettingResponse,
            playerListResponse,
            systemNoticeResponse);
    }
```
- 방 퇴장(삭제시) 원자성 구현을 위해 remove 를 마지막 순서로 이동함 
```
            room.getUserIdSessionMap().remove(removePlayer.getId());
            playerSessionMap.remove(sessionId);

            SystemNoticeResponse systemNoticeResponse =
                ofPlayerEvent(removePlayer, RoomEventType.EXIT);

            PlayerListResponse playerListResponse = toPlayerListResponse(room);

            return new RoomExitData(destination, playerListResponse, systemNoticeResponse, false);
        }
```



## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


## 소감 
구현보다 테스트가 너무나 힘들었네요 ^_ㅠ