### PR TITLE
[feat] 관리자 로그인/로그아웃, 인증 정보 조회 기능

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/admin/app/AdminDetailService.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/AdminDetailService.java
@@ -1,0 +1,29 @@
+package io.f1.backend.domain.admin.app;
+
+import static io.f1.backend.domain.user.constants.SessionKeys.ADMIN;
+
+import io.f1.backend.domain.admin.dao.AdminRepository;
+import io.f1.backend.domain.admin.dto.AdminPrincipal;
+import io.f1.backend.domain.admin.dto.AuthenticationAdmin;
+import io.f1.backend.domain.admin.entity.Admin;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDetailService implements UserDetailsService {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Admin admin = adminRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("E404007: 존재하지 않는 관리자입니다."));
+        // 프론트엔드로 내려가지 않는 예외
+        return new AdminPrincipal(admin);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/AdminDetailService.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/AdminDetailService.java
@@ -1,13 +1,12 @@
 package io.f1.backend.domain.admin.app;
 
-import static io.f1.backend.domain.user.constants.SessionKeys.ADMIN;
 
 import io.f1.backend.domain.admin.dao.AdminRepository;
 import io.f1.backend.domain.admin.dto.AdminPrincipal;
-import io.f1.backend.domain.admin.dto.AuthenticationAdmin;
 import io.f1.backend.domain.admin.entity.Admin;
-import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -21,8 +20,11 @@ public class AdminDetailService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Admin admin = adminRepository.findByUsername(username)
-            .orElseThrow(() -> new UsernameNotFoundException("E404007: 존재하지 않는 관리자입니다."));
+        Admin admin =
+                adminRepository
+                        .findByUsername(username)
+                        .orElseThrow(
+                                () -> new UsernameNotFoundException("E404007: 존재하지 않는 관리자입니다."));
         // 프론트엔드로 내려가지 않는 예외
         return new AdminPrincipal(admin);
     }

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginFailureHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginFailureHandler.java
@@ -1,0 +1,32 @@
+package io.f1.backend.domain.admin.app.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.f1.backend.domain.admin.dto.AdminLoginFailResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminLoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType("application/json;charset=UTF-8");
+
+        AdminLoginFailResponseDto errorResponse = new AdminLoginFailResponseDto(
+            "E401005",
+            "아이디 또는 비밀번호가 일치하지 않습니다."
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginFailureHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginFailureHandler.java
@@ -1,14 +1,19 @@
 package io.f1.backend.domain.admin.app.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.f1.backend.domain.admin.dto.AdminLoginFailResponseDto;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -17,15 +22,16 @@ public class AdminLoginFailureHandler implements AuthenticationFailureHandler {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException exception) throws IOException {
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception)
+            throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
         response.setContentType("application/json;charset=UTF-8");
 
-        AdminLoginFailResponseDto errorResponse = new AdminLoginFailResponseDto(
-            "E401005",
-            "아이디 또는 비밀번호가 일치하지 않습니다."
-        );
+        AdminLoginFailResponseDto errorResponse =
+                new AdminLoginFailResponseDto("E401005", "아이디 또는 비밀번호가 일치하지 않습니다.");
 
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginSuccessHandler.java
@@ -6,14 +6,18 @@ import static io.f1.backend.global.util.SecurityUtils.getCurrentAdminPrincipal;
 import io.f1.backend.domain.admin.dao.AdminRepository;
 import io.f1.backend.domain.admin.dto.AdminPrincipal;
 import io.f1.backend.domain.admin.entity.Admin;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -24,13 +28,15 @@ public class AdminLoginSuccessHandler implements AuthenticationSuccessHandler {
 
     @Override
     public void onAuthenticationSuccess(
-        HttpServletRequest request,
-        HttpServletResponse response,
-        Authentication authentication) {
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) {
 
         AdminPrincipal principal = getCurrentAdminPrincipal();
-        Admin admin = adminRepository.findByUsername(principal.getUsername())
-            .orElseThrow(() -> new RuntimeException("E404007: 존재하지 않는 관리자입니다."));
+        Admin admin =
+                adminRepository
+                        .findByUsername(principal.getUsername())
+                        .orElseThrow(() -> new RuntimeException("E404007: 존재하지 않는 관리자입니다."));
 
         admin.updateLastLogin(LocalDateTime.now());
         adminRepository.save(admin);

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginSuccessHandler.java
@@ -1,0 +1,32 @@
+package io.f1.backend.domain.admin.app.handler;
+
+import static io.f1.backend.domain.user.constants.SessionKeys.ADMIN;
+import static io.f1.backend.global.util.SecurityUtils.getCurrentAdminPrincipal;
+
+import io.f1.backend.domain.admin.dto.AdminPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final HttpSession httpSession;
+
+    @Override
+    public void onAuthenticationSuccess(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication) {
+
+        AdminPrincipal principal = getCurrentAdminPrincipal();
+        httpSession.setAttribute(ADMIN, principal.getAuthenticationAdmin());
+
+        response.setStatus(HttpServletResponse.SC_OK); // 200
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/handler/AdminLoginSuccessHandler.java
@@ -3,10 +3,13 @@ package io.f1.backend.domain.admin.app.handler;
 import static io.f1.backend.domain.user.constants.SessionKeys.ADMIN;
 import static io.f1.backend.global.util.SecurityUtils.getCurrentAdminPrincipal;
 
+import io.f1.backend.domain.admin.dao.AdminRepository;
 import io.f1.backend.domain.admin.dto.AdminPrincipal;
+import io.f1.backend.domain.admin.entity.Admin;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AdminLoginSuccessHandler implements AuthenticationSuccessHandler {
 
+    private final AdminRepository adminRepository;
     private final HttpSession httpSession;
 
     @Override
@@ -25,6 +29,11 @@ public class AdminLoginSuccessHandler implements AuthenticationSuccessHandler {
         Authentication authentication) {
 
         AdminPrincipal principal = getCurrentAdminPrincipal();
+        Admin admin = adminRepository.findByUsername(principal.getUsername())
+            .orElseThrow(() -> new RuntimeException("E404007: 존재하지 않는 관리자입니다."));
+
+        admin.updateLastLogin(LocalDateTime.now());
+        adminRepository.save(admin);
         httpSession.setAttribute(ADMIN, principal.getAuthenticationAdmin());
 
         response.setStatus(HttpServletResponse.SC_OK); // 200

--- a/backend/src/main/java/io/f1/backend/domain/admin/dao/AdminRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/dao/AdminRepository.java
@@ -1,13 +1,14 @@
 package io.f1.backend.domain.admin.dao;
 
 import io.f1.backend.domain.admin.entity.Admin;
-import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 
     Optional<Admin> findByUsername(String username);
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/admin/dao/AdminRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/dao/AdminRepository.java
@@ -1,0 +1,13 @@
+package io.f1.backend.domain.admin.dao;
+
+import io.f1.backend.domain.admin.entity.Admin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByUsername(String username);
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/dto/AdminLoginFailResponseDto.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/dto/AdminLoginFailResponseDto.java
@@ -1,0 +1,11 @@
+package io.f1.backend.domain.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminLoginFailResponseDto {
+    private String code;
+    private String message;
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/dto/AdminPrincipal.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/dto/AdminPrincipal.java
@@ -1,11 +1,14 @@
 package io.f1.backend.domain.admin.dto;
 
 import io.f1.backend.domain.admin.entity.Admin;
-import java.util.Collection;
-import java.util.Collections;
+
 import lombok.Getter;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 public class AdminPrincipal implements UserDetails {

--- a/backend/src/main/java/io/f1/backend/domain/admin/dto/AdminPrincipal.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/dto/AdminPrincipal.java
@@ -1,0 +1,56 @@
+package io.f1.backend.domain.admin.dto;
+
+import io.f1.backend.domain.admin.entity.Admin;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class AdminPrincipal implements UserDetails {
+
+    public static final String ROLE_ADMIN = "ROLE_ADMIN";
+    private final AuthenticationAdmin authenticationAdmin;
+    private final String password;
+
+    public AdminPrincipal(Admin admin) {
+        this.authenticationAdmin = AuthenticationAdmin.from(admin);
+        this.password = admin.getPassword();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> ROLE_ADMIN);
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return authenticationAdmin.username();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/dto/AuthenticationAdmin.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/dto/AuthenticationAdmin.java
@@ -1,0 +1,10 @@
+package io.f1.backend.domain.admin.dto;
+
+import io.f1.backend.domain.admin.entity.Admin;
+
+public record AuthenticationAdmin(Long adminId, String username) {
+
+    public static AuthenticationAdmin from(Admin admin) {
+        return new AuthenticationAdmin(admin.getId(), admin.getUsername());
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/admin/entity/Admin.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/entity/Admin.java
@@ -9,8 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Admin extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/io/f1/backend/domain/admin/entity/Admin.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/entity/Admin.java
@@ -27,4 +27,8 @@ public class Admin extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime lastLogin;
+
+    public void updateLastLogin(LocalDateTime lastLogin) {
+        this.lastLogin = lastLogin;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/admin/entity/Admin.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/entity/Admin.java
@@ -8,8 +8,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
-import java.time.LocalDateTime;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/backend/src/main/java/io/f1/backend/domain/auth/api/AuthController.java
+++ b/backend/src/main/java/io/f1/backend/domain/auth/api/AuthController.java
@@ -1,0 +1,30 @@
+package io.f1.backend.domain.auth.api;
+
+import static io.f1.backend.global.util.SecurityUtils.getAuthentication;
+
+import io.f1.backend.domain.admin.dto.AdminPrincipal;
+import io.f1.backend.domain.auth.dto.CurrentUserAndAdminResponse;
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUserOrAdmin() {
+        Authentication authentication = getAuthentication();
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof UserPrincipal userPrincipal) {
+            return ResponseEntity.ok(CurrentUserAndAdminResponse.from(userPrincipal));
+        }
+        return ResponseEntity.ok(CurrentUserAndAdminResponse.from((AdminPrincipal) principal));
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/auth/api/AuthController.java
+++ b/backend/src/main/java/io/f1/backend/domain/auth/api/AuthController.java
@@ -5,7 +5,9 @@ import static io.f1.backend.global.util.SecurityUtils.getAuthentication;
 import io.f1.backend.domain.admin.dto.AdminPrincipal;
 import io.f1.backend.domain.auth.dto.CurrentUserAndAdminResponse;
 import io.f1.backend.domain.user.dto.UserPrincipal;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/io/f1/backend/domain/auth/dto/CurrentUserAndAdminResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/auth/dto/CurrentUserAndAdminResponse.java
@@ -1,0 +1,23 @@
+package io.f1.backend.domain.auth.dto;
+
+import io.f1.backend.domain.admin.dto.AdminPrincipal;
+import io.f1.backend.domain.user.dto.UserPrincipal;
+
+public record CurrentUserAndAdminResponse(Long id, String name, String role) {
+
+    public static CurrentUserAndAdminResponse from(UserPrincipal userPrincipal) {
+        return new CurrentUserAndAdminResponse(
+            userPrincipal.getUserId(),
+            userPrincipal.getUserNickname(),
+            UserPrincipal.ROLE_USER
+        );
+    }
+
+    public static CurrentUserAndAdminResponse from(AdminPrincipal adminPrincipal) {
+        return new CurrentUserAndAdminResponse(
+            adminPrincipal.getAuthenticationAdmin().adminId(),
+            adminPrincipal.getUsername(),
+            AdminPrincipal.ROLE_ADMIN
+        );
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/auth/dto/CurrentUserAndAdminResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/auth/dto/CurrentUserAndAdminResponse.java
@@ -7,17 +7,15 @@ public record CurrentUserAndAdminResponse(Long id, String name, String role) {
 
     public static CurrentUserAndAdminResponse from(UserPrincipal userPrincipal) {
         return new CurrentUserAndAdminResponse(
-            userPrincipal.getUserId(),
-            userPrincipal.getUserNickname(),
-            UserPrincipal.ROLE_USER
-        );
+                userPrincipal.getUserId(),
+                userPrincipal.getUserNickname(),
+                UserPrincipal.ROLE_USER);
     }
 
     public static CurrentUserAndAdminResponse from(AdminPrincipal adminPrincipal) {
         return new CurrentUserAndAdminResponse(
-            adminPrincipal.getAuthenticationAdmin().adminId(),
-            adminPrincipal.getUsername(),
-            AdminPrincipal.ROLE_ADMIN
-        );
+                adminPrincipal.getAuthenticationAdmin().adminId(),
+                adminPrincipal.getUsername(),
+                AdminPrincipal.ROLE_ADMIN);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/app/handler/UserAndAdminLogoutSuccessHandler.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/handler/UserAndAdminLogoutSuccessHandler.java
@@ -8,7 +8,7 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import org.springframework.stereotype.Component;
 
 @Component
-public class OAuthLogoutSuccessHandler implements LogoutSuccessHandler {
+public class UserAndAdminLogoutSuccessHandler implements LogoutSuccessHandler {
 
     @Override
     public void onLogoutSuccess(

--- a/backend/src/main/java/io/f1/backend/domain/user/constants/SessionKeys.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/constants/SessionKeys.java
@@ -6,4 +6,5 @@ public final class SessionKeys {
 
     public static final String OAUTH_USER = "OAuthUser";
     public static final String USER = "user";
+    public static final String ADMIN = "admin";
 }

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -4,8 +4,8 @@ import io.f1.backend.domain.admin.app.handler.AdminLoginFailureHandler;
 import io.f1.backend.domain.admin.app.handler.AdminLoginSuccessHandler;
 import io.f1.backend.domain.user.app.CustomOAuthUserService;
 import io.f1.backend.domain.user.app.handler.CustomAuthenticationEntryPoint;
-import io.f1.backend.domain.user.app.handler.UserAndAdminLogoutSuccessHandler;
 import io.f1.backend.domain.user.app.handler.OAuthSuccessHandler;
+import io.f1.backend.domain.user.app.handler.UserAndAdminLogoutSuccessHandler;
 
 import lombok.RequiredArgsConstructor;
 
@@ -55,12 +55,12 @@ public class SecurityConfig {
                                         .hasAnyRole("USER", "ADMIN")
                                         .anyRequest()
                                         .authenticated())
-                .formLogin(form -> form
-                    .loginProcessingUrl("/admin/login") // 로그인 form action 경로
-                    .successHandler(adminLoginSuccessHandler)
-                    .failureHandler(adminLoginFailureHandler)
-                    .permitAll()
-                )
+                .formLogin(
+                        form ->
+                                form.loginProcessingUrl("/admin/login") // 로그인 form action 경로
+                                        .successHandler(adminLoginSuccessHandler)
+                                        .failureHandler(adminLoginFailureHandler)
+                                        .permitAll())
                 .oauth2Login(
                         oauth2 ->
                                 oauth2.userInfoEndpoint(

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package io.f1.backend.global.config;
 
+import io.f1.backend.domain.admin.app.handler.AdminLoginFailureHandler;
+import io.f1.backend.domain.admin.app.handler.AdminLoginSuccessHandler;
 import io.f1.backend.domain.user.app.CustomOAuthUserService;
 import io.f1.backend.domain.user.app.handler.CustomAuthenticationEntryPoint;
 import io.f1.backend.domain.user.app.handler.OAuthLogoutSuccessHandler;
@@ -23,6 +25,8 @@ public class SecurityConfig {
     private final CustomOAuthUserService customOAuthUserService;
     private final OAuthSuccessHandler oAuthSuccessHandler;
     private final OAuthLogoutSuccessHandler oAuthLogoutSuccessHandler;
+    private final AdminLoginSuccessHandler adminLoginSuccessHandler;
+    private final AdminLoginFailureHandler adminLoginFailureHandler;
 
     @Bean
     public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
@@ -38,15 +42,23 @@ public class SecurityConfig {
                                                 "/oauth2/**",
                                                 "/signup",
                                                 "/css/**",
-                                                "/js/**")
+                                                "/js/**",
+                                                "/admin/login")
                                         .permitAll()
                                         .requestMatchers("/ws/**")
                                         .authenticated()
                                         .requestMatchers("/user/me")
                                         .hasRole("USER")
+                                        .requestMatchers("/admin/**")
+                                        .hasRole("ADMIN")
                                         .anyRequest()
                                         .authenticated())
-                .formLogin(AbstractHttpConfigurer::disable)
+                .formLogin(form -> form
+                    .loginProcessingUrl("/admin/login") // 로그인 form action 경로
+                    .successHandler(adminLoginSuccessHandler)
+                    .failureHandler(adminLoginFailureHandler)
+                    .permitAll()
+                )
                 .oauth2Login(
                         oauth2 ->
                                 oauth2.userInfoEndpoint(

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import io.f1.backend.domain.admin.app.handler.AdminLoginFailureHandler;
 import io.f1.backend.domain.admin.app.handler.AdminLoginSuccessHandler;
 import io.f1.backend.domain.user.app.CustomOAuthUserService;
 import io.f1.backend.domain.user.app.handler.CustomAuthenticationEntryPoint;
-import io.f1.backend.domain.user.app.handler.OAuthLogoutSuccessHandler;
+import io.f1.backend.domain.user.app.handler.UserAndAdminLogoutSuccessHandler;
 import io.f1.backend.domain.user.app.handler.OAuthSuccessHandler;
 
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomOAuthUserService customOAuthUserService;
     private final OAuthSuccessHandler oAuthSuccessHandler;
-    private final OAuthLogoutSuccessHandler oAuthLogoutSuccessHandler;
+    private final UserAndAdminLogoutSuccessHandler userAndAdminLogoutSuccessHandler;
     private final AdminLoginSuccessHandler adminLoginSuccessHandler;
     private final AdminLoginFailureHandler adminLoginFailureHandler;
 
@@ -69,7 +69,7 @@ public class SecurityConfig {
                 .logout(
                         logout ->
                                 logout.logoutUrl("/logout")
-                                        .logoutSuccessHandler(oAuthLogoutSuccessHandler)
+                                        .logoutSuccessHandler(userAndAdminLogoutSuccessHandler)
                                         .clearAuthentication(true)
                                         .invalidateHttpSession(true)
                                         .permitAll())

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                                         .hasRole("USER")
                                         .requestMatchers("/admin/**")
                                         .hasRole("ADMIN")
+                                        .requestMatchers("/auth/me")
+                                        .hasAnyRole("USER", "ADMIN")
                                         .anyRequest()
                                         .authenticated())
                 .formLogin(form -> form

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -3,31 +3,29 @@ package io.f1.backend.global.util;
 import io.f1.backend.domain.admin.dto.AdminPrincipal;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
-
 import jakarta.servlet.http.HttpSession;
-
+import java.util.Collections;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.Collections;
-
 public class SecurityUtils {
 
-    private SecurityUtils() {}
+    private SecurityUtils() {
+    }
 
     public static void setAuthentication(User user) {
         UserPrincipal userPrincipal = new UserPrincipal(user, Collections.emptyMap());
         UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(
-                        userPrincipal, null, userPrincipal.getAuthorities());
+            new UsernamePasswordAuthenticationToken(
+                userPrincipal, null, userPrincipal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     public static UserPrincipal getCurrentUserPrincipal() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null
-                && authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
+            && authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
             return userPrincipal;
         }
         throw new RuntimeException("E401001: 로그인이 필요합니다.");
@@ -59,5 +57,9 @@ public class SecurityUtils {
             return adminPrincipal;
         }
         throw new RuntimeException("E401001: 로그인이 필요합니다.");
+    }
+
+    public static Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -3,29 +3,31 @@ package io.f1.backend.global.util;
 import io.f1.backend.domain.admin.dto.AdminPrincipal;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
+
 import jakarta.servlet.http.HttpSession;
-import java.util.Collections;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.Collections;
+
 public class SecurityUtils {
 
-    private SecurityUtils() {
-    }
+    private SecurityUtils() {}
 
     public static void setAuthentication(User user) {
         UserPrincipal userPrincipal = new UserPrincipal(user, Collections.emptyMap());
         UsernamePasswordAuthenticationToken authentication =
-            new UsernamePasswordAuthenticationToken(
-                userPrincipal, null, userPrincipal.getAuthorities());
+                new UsernamePasswordAuthenticationToken(
+                        userPrincipal, null, userPrincipal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     public static UserPrincipal getCurrentUserPrincipal() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null
-            && authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
+                && authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
             return userPrincipal;
         }
         throw new RuntimeException("E401001: 로그인이 필요합니다.");
@@ -53,7 +55,7 @@ public class SecurityUtils {
     public static AdminPrincipal getCurrentAdminPrincipal() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null
-            && authentication.getPrincipal() instanceof AdminPrincipal adminPrincipal) {
+                && authentication.getPrincipal() instanceof AdminPrincipal adminPrincipal) {
             return adminPrincipal;
         }
         throw new RuntimeException("E401001: 로그인이 필요합니다.");

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -1,5 +1,6 @@
 package io.f1.backend.global.util;
 
+import io.f1.backend.domain.admin.dto.AdminPrincipal;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
 
@@ -49,5 +50,14 @@ public class SecurityUtils {
 
     private static void clearAuthentication() {
         SecurityContextHolder.clearContext();
+    }
+
+    public static AdminPrincipal getCurrentAdminPrincipal() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null
+            && authentication.getPrincipal() instanceof AdminPrincipal adminPrincipal) {
+            return adminPrincipal;
+        }
+        throw new RuntimeException("E401001: 로그인이 필요합니다.");
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #46 

## 🪐 작업 내용
- 관리자 form 로그인을 구현했습니다.
    - 관리자 로그인 화면에서 form 방식으로 /admin/login 요청을 보내면 Spring Security 인증 절차에 따라 요청이 처리됩니다.
    - Admin 엔티티에 대한 쿼리를 날리는 방식으로 생성하고 테스트 했습니다.
    - 처음엔 비밀번호 평문에 대한 해시 값을 생성해서 실행했지만, 비밀번호에 의도적으로 해시값을 넣은 경우에 Spring Security에서 예외가 발생했습니다. 그래서 비밀번호 필드에 {noop} 키워드를 붙여 생성하니 해결되었습니다.
    - `INSERT INTO admin (username, password, last_login) VALUES ('admin', '{noop}1234', NOW());`
- 관리자 로그아웃을 구현했습니다.
    - 관리자 로그인 화면의 경로를 알고 있다는 가정을 하기로 결정했기 때문에, 이전에 구현했던 사용자 로그아웃 기능과 통합했습니다.
    - 이 때, 사용자 로그아웃과 관리자 로그아웃을 모두 담당한다는 의미를 담아 클래스명을 바꿨습니다.
- 인증 정보 조회 기능을 구현했습니다.
    - /auth/me로 요청을 보내면 요청을 보낸 사용자/관리자의 인증 정보를 조회할 수 있습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?