### PR TITLE
[refactor] Mapper에서 NPE 요소 제거하기 + 커스텀 예외 적용하기

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -10,10 +10,10 @@ import io.f1.backend.domain.game.model.RoomState;
 import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
-
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.GameErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -32,9 +32,9 @@ public class GameService {
     public GameStartData gameStart(Long roomId, Long quizId) {
 
         Room room =
-            roomRepository
-                .findRoom(roomId)
-                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
+                roomRepository
+                        .findRoom(roomId)
+                        .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
 
         if (!validateReadyStatus(room)) {
             throw new CustomException(RoomErrorCode.PLAYER_NOT_READY);

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -11,6 +11,9 @@ import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.GameErrorCode;
+import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -29,12 +32,12 @@ public class GameService {
     public GameStartData gameStart(Long roomId, Long quizId) {
 
         Room room =
-                roomRepository
-                        .findRoom(roomId)
-                        .orElseThrow(() -> new IllegalArgumentException("404 존재하지 않는 방입니다."));
+            roomRepository
+                .findRoom(roomId)
+                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
 
         if (!validateReadyStatus(room)) {
-            throw new IllegalArgumentException("E403004 : 레디 상태가 아닙니다.");
+            throw new CustomException(RoomErrorCode.PLAYER_NOT_READY);
         }
 
         // 방의 gameSetting에 설정된 퀴즈랑 요청 퀴즈랑 같은지 체크 후 GameSetting에서 라운드 가져오기
@@ -58,7 +61,7 @@ public class GameService {
         GameSetting gameSetting = room.getGameSetting();
 
         if (!gameSetting.checkQuizId(quizId)) {
-            throw new IllegalArgumentException("E409002 : 게임 설정이 다릅니다. (게임을 시작할 수 없습니다.)");
+            throw new CustomException(GameErrorCode.GAME_SETTING_CONFLICT);
         }
 
         return gameSetting.getRound();

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -10,6 +10,8 @@ import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.QuestionErrorCode;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -44,7 +46,7 @@ public class QuestionService {
         Question question =
                 questionRepository
                         .findById(questionId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+                        .orElseThrow(() -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         TextQuestion textQuestion = question.getTextQuestion();
         textQuestion.changeContent(content);
@@ -58,7 +60,7 @@ public class QuestionService {
         Question question =
                 questionRepository
                         .findById(questionId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+                        .orElseThrow(() -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         question.changeAnswer(answer);
     }
@@ -69,20 +71,20 @@ public class QuestionService {
         Question question =
                 questionRepository
                         .findById(questionId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 문제입니다."));
+                        .orElseThrow(() -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         questionRepository.delete(question);
     }
 
     private void validateAnswer(String answer) {
         if (answer.trim().length() < 5 || answer.trim().length() > 30) {
-            throw new IllegalArgumentException("정답은 1자 이상 30자 이하로 입력해주세요.");
+            throw new CustomException(QuestionErrorCode.INVALID_ANSWER_LENGTH);
         }
     }
 
     private void validateContent(String content) {
         if (content.trim().length() < 5 || content.trim().length() > 30) {
-            throw new IllegalArgumentException("문제는 5자 이상 30자 이하로 입력해주세요.");
+            throw new CustomException(QuestionErrorCode.INVALID_CONTENT_LENGTH);
         }
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -9,15 +9,13 @@ import io.f1.backend.domain.question.dto.QuestionRequest;
 import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.quiz.entity.Quiz;
-
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.QuestionErrorCode;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +44,8 @@ public class QuestionService {
         Question question =
                 questionRepository
                         .findById(questionId)
-                        .orElseThrow(() -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
+                        .orElseThrow(
+                                () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         TextQuestion textQuestion = question.getTextQuestion();
         textQuestion.changeContent(content);
@@ -60,7 +59,8 @@ public class QuestionService {
         Question question =
                 questionRepository
                         .findById(questionId)
-                        .orElseThrow(() -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
+                        .orElseThrow(
+                                () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         question.changeAnswer(answer);
     }
@@ -71,7 +71,8 @@ public class QuestionService {
         Question question =
                 questionRepository
                         .findById(questionId)
-                        .orElseThrow(() -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
+                        .orElseThrow(
+                                () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         questionRepository.delete(question);
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -6,10 +6,9 @@ import io.f1.backend.domain.quiz.dto.QuizCreateResponse;
 import io.f1.backend.domain.quiz.dto.QuizListPageResponse;
 import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.dto.QuizUpdateRequest;
-
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.CommonErrorCode;
-import io.f1.backend.global.exception.errorcode.QuizErrorCode;
+
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
@@ -82,10 +81,10 @@ public class QuizController {
             @RequestParam(required = false) String title,
             @RequestParam(required = false) String creator) {
 
-        if(page <= 0) {
+        if (page <= 0) {
             throw new CustomException(CommonErrorCode.INVALID_PAGINATION);
         }
-        if(size <= 0 || size > 100) {
+        if (size <= 0 || size > 100) {
             throw new CustomException(CommonErrorCode.INVALID_PAGINATION);
         }
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -28,8 +28,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 @RestController
 @RequestMapping("/quizzes")
 @RequiredArgsConstructor

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -40,8 +40,7 @@ public class QuizController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<QuizCreateResponse> saveQuiz(
             @RequestPart(required = false) MultipartFile thumbnailFile,
-            @Valid @RequestPart QuizCreateRequest request)
-            throws IOException {
+            @Valid @RequestPart QuizCreateRequest request) {
         QuizCreateResponse response = quizService.saveQuiz(thumbnailFile, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -58,8 +57,7 @@ public class QuizController {
     public ResponseEntity<Void> updateQuiz(
             @PathVariable Long quizId,
             @RequestPart(required = false) MultipartFile thumbnailFile,
-            @RequestPart QuizUpdateRequest request)
-            throws IOException {
+            @RequestPart QuizUpdateRequest request) {
 
         if (request.title() != null) {
             quizService.updateQuizTitle(quizId, request.title());

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -7,6 +7,9 @@ import io.f1.backend.domain.quiz.dto.QuizListPageResponse;
 import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.dto.QuizUpdateRequest;
 
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.CommonErrorCode;
+import io.f1.backend.global.exception.errorcode.QuizErrorCode;
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
@@ -78,6 +81,13 @@ public class QuizController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) String creator) {
+
+        if(page <= 0) {
+            throw new CustomException(CommonErrorCode.INVALID_PAGINATION);
+        }
+        if(size <= 0 || size > 100) {
+            throw new CustomException(CommonErrorCode.INVALID_PAGINATION);
+        }
 
         Pageable pageable =
                 PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -17,10 +17,10 @@ import io.f1.backend.domain.quiz.dto.QuizQuestionListResponse;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.entity.User;
-
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.QuizErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -93,12 +93,12 @@ public class QuizService {
             throw new CustomException(QuizErrorCode.UNSUPPORTED_IMAGE_FORMAT);
         }
 
-        if(thumbnailFile.getSize() > MAX_FILE_SIZE) {
+        if (thumbnailFile.getSize() > MAX_FILE_SIZE) {
             throw new CustomException(QuizErrorCode.FILE_SIZE_TOO_LARGE);
         }
     }
 
-    private String convertToThumbnailPath(MultipartFile thumbnailFile){
+    private String convertToThumbnailPath(MultipartFile thumbnailFile) {
         String originalFilename = thumbnailFile.getOriginalFilename();
         String ext = getExtension(originalFilename);
         String savedFilename = UUID.randomUUID().toString() + "." + ext;

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -18,6 +18,9 @@ import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.entity.User;
 
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.AuthErrorCode;
+import io.f1.backend.global.exception.errorcode.QuizErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,6 +51,7 @@ public class QuizService {
     private String defaultThumbnailPath;
 
     private final String DEFAULT = "default";
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
     // TODO : 시큐리티 구현 이후 삭제해도 되는 의존성 주입
     private final UserRepository userRepository;
@@ -55,8 +59,7 @@ public class QuizService {
     private final QuizRepository quizRepository;
 
     @Transactional
-    public QuizCreateResponse saveQuiz(MultipartFile thumbnailFile, QuizCreateRequest request)
-            throws IOException {
+    public QuizCreateResponse saveQuiz(MultipartFile thumbnailFile, QuizCreateRequest request) {
         String thumbnailPath = defaultThumbnailPath;
 
         if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
@@ -81,29 +84,38 @@ public class QuizService {
     private void validateImageFile(MultipartFile thumbnailFile) {
 
         if (!thumbnailFile.getContentType().startsWith("image")) {
-            // TODO : 이후 커스텀 예외로 변경
-            throw new IllegalArgumentException("이미지 파일을 업로드해주세요.");
+            throw new CustomException(QuizErrorCode.UNSUPPORTED_MEDIA_TYPE);
         }
 
         List<String> allowedExt = List.of("jpg", "jpeg", "png", "webp");
-        if (!allowedExt.contains(getExtension(thumbnailFile.getOriginalFilename()))) {
-            throw new IllegalArgumentException("지원하지 않는 확장자입니다.");
+        String ext = getExtension(thumbnailFile.getOriginalFilename());
+        if (!allowedExt.contains(ext)) {
+            throw new CustomException(QuizErrorCode.UNSUPPORTED_IMAGE_FORMAT);
+        }
+
+        if(thumbnailFile.getSize() > MAX_FILE_SIZE) {
+            throw new CustomException(QuizErrorCode.FILE_SIZE_TOO_LARGE);
         }
     }
 
-    private String convertToThumbnailPath(MultipartFile thumbnailFile) throws IOException {
+    private String convertToThumbnailPath(MultipartFile thumbnailFile){
         String originalFilename = thumbnailFile.getOriginalFilename();
         String ext = getExtension(originalFilename);
         String savedFilename = UUID.randomUUID().toString() + "." + ext;
 
-        Path savePath = Paths.get(uploadPath, savedFilename).toAbsolutePath();
-        thumbnailFile.transferTo(savePath.toFile());
+        try {
+            Path savePath = Paths.get(uploadPath, savedFilename).toAbsolutePath();
+            thumbnailFile.transferTo(savePath.toFile());
+        } catch (IOException e) {
+            log.error("썸네일 업로드 중 IOException 발생", e);
+            throw new CustomException(QuizErrorCode.THUMBNAIL_SAVE_FAILED);
+        }
 
         return "/images/thumbnail/" + savedFilename;
     }
 
     private String getExtension(String filename) {
-        return filename.substring(filename.lastIndexOf(".") + 1);
+        return filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
     }
 
     @Transactional
@@ -112,11 +124,11 @@ public class QuizService {
         Quiz quiz =
                 quizRepository
                         .findById(quizId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         // TODO : util 메서드에서 사용자 ID 꺼내쓰는 식으로 수정하기
         if (1L != quiz.getCreator().getId()) {
-            throw new RuntimeException("권한이 없습니다.");
+            throw new CustomException(AuthErrorCode.FORBIDDEN);
         }
 
         deleteThumbnailFile(quiz.getThumbnailUrl());
@@ -128,7 +140,7 @@ public class QuizService {
         Quiz quiz =
                 quizRepository
                         .findById(quizId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateTitle(title);
         quiz.changeTitle(title);
@@ -140,19 +152,19 @@ public class QuizService {
         Quiz quiz =
                 quizRepository
                         .findById(quizId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateDesc(description);
         quiz.changeDescription(description);
     }
 
     @Transactional
-    public void updateThumbnail(Long quizId, MultipartFile thumbnailFile) throws IOException {
+    public void updateThumbnail(Long quizId, MultipartFile thumbnailFile) {
 
         Quiz quiz =
                 quizRepository
                         .findById(quizId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateImageFile(thumbnailFile);
         String newThumbnailPath = convertToThumbnailPath(thumbnailFile);
@@ -163,13 +175,13 @@ public class QuizService {
 
     private void validateDesc(String desc) {
         if (desc.trim().length() < 10 || desc.trim().length() > 50) {
-            throw new IllegalArgumentException("설명은 10자 이상 50자 이하로 입력해주세요.");
+            throw new CustomException(QuizErrorCode.INVALID_DESC_LENGTH);
         }
     }
 
     private void validateTitle(String title) {
         if (title.trim().length() < 2 || title.trim().length() > 30) {
-            throw new IllegalArgumentException("제목은 2자 이상 30자 이하로 입력해주세요.");
+            throw new CustomException(QuizErrorCode.INVALID_TITLE_LENGTH);
         }
     }
 
@@ -192,7 +204,7 @@ public class QuizService {
             }
         } catch (IOException e) {
             log.error("기존 썸네일 삭제 중 오류 : {}", filePath);
-            throw new RuntimeException(e);
+            throw new CustomException(QuizErrorCode.THUMBNAIL_DELETE_FAILED);
         }
     }
 
@@ -202,9 +214,9 @@ public class QuizService {
         Page<Quiz> quizzes;
 
         // 검색어가 있을 때
-        if (StringUtils.isBlank(title)) {
+        if (!StringUtils.isBlank(title)) {
             quizzes = quizRepository.findQuizzesByTitleContaining(title, pageable);
-        } else if (StringUtils.isBlank(creator)) {
+        } else if (!StringUtils.isBlank(creator)) {
             quizzes = quizRepository.findQuizzesByCreator_NicknameContaining(creator, pageable);
         } else { // 검색어가 없을 때 혹은 빈 문자열일 때
             quizzes = quizRepository.findAll(pageable);
@@ -220,7 +232,7 @@ public class QuizService {
         Quiz quiz =
                 quizRepository
                         .findQuizWithQuestionsById(quizId)
-                        .orElseThrow(() -> new RuntimeException("E404002: 존재하지 않는 퀴즈입니다."));
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
         return quiz;
     }
 
@@ -234,7 +246,7 @@ public class QuizService {
         Quiz quiz =
                 quizRepository
                         .findById(quizId)
-                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         return quizToQuizQuestionListResponse(quiz);
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -83,20 +83,18 @@ public class Quiz extends BaseEntity {
     }
 
     public Long getUserIdIfExists() {
-        Long userId = null;
-        if (this.creator != null) {
-            userId = this.creator.getId();
+        if (this.creator == null) {
+            return null;
         }
 
-        return userId;
+        return this.creator.getId();
     }
 
     public String getUserNicknameIfExists() {
-        String nickname = null;
-        if (this.creator != null) {
-            nickname = this.creator.getNickname();
+        if (this.creator == null) {
+            return "탈퇴한 사용자";
         }
 
-        return nickname;
+        return this.creator.getNickname();
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -82,7 +82,7 @@ public class Quiz extends BaseEntity {
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    public Long getUserIdIfExists() {
+    public Long findCreatorId() {
         if (this.creator == null) {
             return null;
         }
@@ -90,7 +90,7 @@ public class Quiz extends BaseEntity {
         return this.creator.getId();
     }
 
-    public String getUserNicknameIfExists() {
+    public String findCreatorNickname() {
         if (this.creator == null) {
             return "탈퇴한 사용자";
         }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -50,7 +50,7 @@ public class Quiz extends BaseEntity {
     private String thumbnailUrl;
 
     @ManyToOne
-    @JoinColumn(name = "creator_id")
+    @JoinColumn(name = "creator_id", nullable = true)
     private User creator;
 
     public Quiz(

--- a/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/entity/Quiz.java
@@ -81,4 +81,22 @@ public class Quiz extends BaseEntity {
     public void changeThumbnailUrl(String thumbnailUrl) {
         this.thumbnailUrl = thumbnailUrl;
     }
+
+    public Long getUserIdIfExists() {
+        Long userId = null;
+        if (this.creator != null) {
+            userId = this.creator.getId();
+        }
+
+        return userId;
+    }
+
+    public String getUserNicknameIfExists() {
+        String nickname = null;
+        if (this.creator != null) {
+            nickname = this.creator.getNickname();
+        }
+
+        return nickname;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -45,7 +45,7 @@ public class QuizMapper {
 
     private static Long getUserIdIfExists(Quiz quiz) {
         Long userId = null;
-        if(quiz.getCreator()!=null){
+        if (quiz.getCreator() != null) {
             userId = quiz.getCreator().getId();
         }
 
@@ -54,7 +54,7 @@ public class QuizMapper {
 
     private static String getUserNicknameIfExists(Quiz quiz) {
         String nickname = null;
-        if(quiz.getCreator()!=null){
+        if (quiz.getCreator() != null) {
             nickname = quiz.getCreator().getNickname();
         }
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -33,13 +33,32 @@ public class QuizMapper {
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {
         // TODO : creatorId 넣어주는 부분에서 Getter를 안 쓰고, 현재 로그인한 유저의 id를 담는 식으로 바꿔도 될 듯
+        getUserIdIfExists(quiz);
         return new QuizCreateResponse(
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getQuizType(),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
-                quiz.getCreator().getId());
+                getUserIdIfExists(quiz));
+    }
+
+    private static Long getUserIdIfExists(Quiz quiz) {
+        Long userId = null;
+        if(quiz.getCreator()!=null){
+            userId = quiz.getCreator().getId();
+        }
+
+        return userId;
+    }
+
+    private static String getUserNicknameIfExists(Quiz quiz) {
+        String nickname = null;
+        if(quiz.getCreator()!=null){
+            nickname = quiz.getCreator().getNickname();
+        }
+
+        return nickname;
     }
 
     public static QuizListResponse quizToQuizListResponse(Quiz quiz) {
@@ -47,7 +66,7 @@ public class QuizMapper {
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getDescription(),
-                quiz.getCreator().getNickname(),
+                getUserNicknameIfExists(quiz),
                 quiz.getQuestions().size(),
                 quiz.getThumbnailUrl());
     }
@@ -79,7 +98,7 @@ public class QuizMapper {
         return new QuizQuestionListResponse(
                 quiz.getTitle(),
                 quiz.getQuizType(),
-                quiz.getCreator().getId(),
+                getUserIdIfExists(quiz),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
                 quiz.getQuestions().size(),

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -33,32 +33,13 @@ public class QuizMapper {
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {
         // TODO : creatorId 넣어주는 부분에서 Getter를 안 쓰고, 현재 로그인한 유저의 id를 담는 식으로 바꿔도 될 듯
-        getUserIdIfExists(quiz);
         return new QuizCreateResponse(
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getQuizType(),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
-                getUserIdIfExists(quiz));
-    }
-
-    private static Long getUserIdIfExists(Quiz quiz) {
-        Long userId = null;
-        if (quiz.getCreator() != null) {
-            userId = quiz.getCreator().getId();
-        }
-
-        return userId;
-    }
-
-    private static String getUserNicknameIfExists(Quiz quiz) {
-        String nickname = null;
-        if (quiz.getCreator() != null) {
-            nickname = quiz.getCreator().getNickname();
-        }
-
-        return nickname;
+                quiz.getUserIdIfExists());
     }
 
     public static QuizListResponse quizToQuizListResponse(Quiz quiz) {
@@ -66,7 +47,7 @@ public class QuizMapper {
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getDescription(),
-                getUserNicknameIfExists(quiz),
+                quiz.getUserNicknameIfExists(),
                 quiz.getQuestions().size(),
                 quiz.getThumbnailUrl());
     }
@@ -98,7 +79,7 @@ public class QuizMapper {
         return new QuizQuestionListResponse(
                 quiz.getTitle(),
                 quiz.getQuizType(),
-                getUserIdIfExists(quiz),
+                quiz.getUserIdIfExists(),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
                 quiz.getQuestions().size(),

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -39,7 +39,7 @@ public class QuizMapper {
                 quiz.getQuizType(),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
-                quiz.getUserIdIfExists());
+                quiz.findCreatorId());
     }
 
     public static QuizListResponse quizToQuizListResponse(Quiz quiz) {
@@ -47,7 +47,7 @@ public class QuizMapper {
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getDescription(),
-                quiz.getUserNicknameIfExists(),
+                quiz.findCreatorNickname(),
                 quiz.getQuestions().size(),
                 quiz.getThumbnailUrl());
     }
@@ -79,7 +79,7 @@ public class QuizMapper {
         return new QuizQuestionListResponse(
                 quiz.getTitle(),
                 quiz.getQuizType(),
-                quiz.getUserIdIfExists(),
+                quiz.findCreatorId(),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
                 quiz.getQuestions().size(),

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                                                 "/oauth2/**",
                                                 "/signup",
                                                 "/css/**",
-                                                "/js/**", "/**")
+                                                "/js/**",
+                                                "/**")
                                         .permitAll()
                                         .requestMatchers("/ws/**")
                                         .authenticated()

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                                                 "/oauth2/**",
                                                 "/signup",
                                                 "/css/**",
-                                                "/js/**")
+                                                "/js/**", "/**")
                                         .permitAll()
                                         .requestMatchers("/ws/**")
                                         .authenticated()

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -38,8 +38,7 @@ public class SecurityConfig {
                                                 "/oauth2/**",
                                                 "/signup",
                                                 "/css/**",
-                                                "/js/**",
-                                                "/**")
+                                                "/js/**")
                                         .permitAll()
                                         .requestMatchers("/ws/**")
                                         .authenticated()

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/GameErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/GameErrorCode.java
@@ -2,12 +2,12 @@ package io.f1.backend.global.exception.errorcode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum GameErrorCode implements ErrorCode {
-
     GAME_SETTING_CONFLICT("E409002", HttpStatus.CONFLICT, "게임 설정이 맞지 않습니다.");
 
     private final String code;

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/GameErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/GameErrorCode.java
@@ -1,0 +1,18 @@
+package io.f1.backend.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GameErrorCode implements ErrorCode {
+
+    GAME_SETTING_CONFLICT("E409002", HttpStatus.CONFLICT, "게임 설정이 맞지 않습니다.");
+
+    private final String code;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuestionErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuestionErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum QuestionErrorCode implements ErrorCode {
+    INVALID_CONTENT_LENGTH("E400011", HttpStatus.BAD_REQUEST, "문제는 5자 이상 30자 이하로 입력해주세요."),
+    INVALID_ANSWER_LENGTH("E400012", HttpStatus.BAD_REQUEST, "정답은 1자 이상 30자 이하로 입력해주세요."),
     QUESTION_NOT_FOUND("E404003", HttpStatus.NOT_FOUND, "존재하지 않는 문제입니다.");
 
     private final String code;

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
@@ -9,9 +9,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum QuizErrorCode implements ErrorCode {
     FILE_SIZE_TOO_LARGE("E400005", HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
+    INVALID_TITLE_LENGTH("E400009", HttpStatus.BAD_REQUEST, "제목은 2자 이상 30자 이하로 입력해주세요."),
+    INVALID_DESC_LENGTH("E400010", HttpStatus.BAD_REQUEST, "설명은 10자 이상 50자 이하로 입력해주세요."),
+    UNSUPPORTED_IMAGE_FORMAT("E400013", HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (jpg, jpeg, png, webp 만 가능)"),
     UNSUPPORTED_MEDIA_TYPE("E415001", HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다."),
     INVALID_FILTER("E400007", HttpStatus.BAD_REQUEST, "title 또는 creator 중 하나만 입력 가능합니다."),
-    QUIZ_NOT_FOUND("E404002", HttpStatus.NOT_FOUND, "존재하지 않는 퀴즈입니다.");
+    QUIZ_NOT_FOUND("E404002", HttpStatus.NOT_FOUND, "존재하지 않는 퀴즈입니다."),
+    THUMBNAIL_SAVE_FAILED("E500002", HttpStatus.INTERNAL_SERVER_ERROR, "썸네일 저장에 실패했습니다."),
+    THUMBNAIL_DELETE_FAILED("E500003", HttpStatus.INTERNAL_SERVER_ERROR, "썸네일 삭제에 실패했습니다.");
 
     private final String code;
 

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/QuizErrorCode.java
@@ -11,7 +11,8 @@ public enum QuizErrorCode implements ErrorCode {
     FILE_SIZE_TOO_LARGE("E400005", HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
     INVALID_TITLE_LENGTH("E400009", HttpStatus.BAD_REQUEST, "제목은 2자 이상 30자 이하로 입력해주세요."),
     INVALID_DESC_LENGTH("E400010", HttpStatus.BAD_REQUEST, "설명은 10자 이상 50자 이하로 입력해주세요."),
-    UNSUPPORTED_IMAGE_FORMAT("E400013", HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (jpg, jpeg, png, webp 만 가능)"),
+    UNSUPPORTED_IMAGE_FORMAT(
+            "E400013", HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (jpg, jpeg, png, webp 만 가능)"),
     UNSUPPORTED_MEDIA_TYPE("E415001", HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다."),
     INVALID_FILTER("E400007", HttpStatus.BAD_REQUEST, "title 또는 creator 중 하나만 입력 가능합니다."),
     QUIZ_NOT_FOUND("E404002", HttpStatus.NOT_FOUND, "존재하지 않는 퀴즈입니다."),

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum RoomErrorCode implements ErrorCode {
     ROOM_USER_LIMIT_REACHED("E403002", HttpStatus.FORBIDDEN, "정원이 모두 찼습니다."),
     ROOM_GAME_IN_PROGRESS("E403003", HttpStatus.FORBIDDEN, "게임이 진행 중 입니다."),
+    PLAYER_NOT_READY("E403004", HttpStatus.FORBIDDEN, "게임 시작을 위한 준비 상태가 아닙니다."),
     ROOM_NOT_FOUND("E404005", HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
     WRONG_PASSWORD("E401006", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지않습니다.");
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 5MB
+
   config:
     import: optional:file:.env[.properties]
 


### PR DESCRIPTION
## 🛰️ Issue Number
- #53 

## 🪐 작업 내용

### 1. 커스텀 예외 적용
추가로 필요한 에러 코드가 있어서 노션에도 추가해뒀습니다 !
`GameService`, `QuizService`, `QuestionService`에 한해서 커스텀 예외로 변경해두었습니다. 

### 2. `QuizMapper`에서 NPE 요소들 수정
- 기존 user가 삭제 될 경우 -> null
- `quiz.getCreator().getId()`, `quiz.getCreator().getNickname()` 을 수정했습니다.
- 따로 메서드를 빼서, user가 null이 아닐 시에는 getter를 사용하고, null일 경우, Id와 Nickname에 null을 반환합니다.

### 3. 기존 StringUtils 조건문 실수
- 지난번 StringUtils로 바꾸고 not 조건을 빼먹어서 페이징이 안되던 거였습니다 하핫.
- 이 부분 수정했습니다 ! 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?