### PR TITLE
[feat] 플레이어 준비 상태 변경 기능

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -32,6 +32,8 @@ import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -182,6 +184,11 @@ public class RoomService {
         }
     }
 
+    public Player findPlayerInRoomBySessionId(String sessionId, Long roomId) {
+        return roomRepository.findPlayerInRoomBySessionId(sessionId, roomId)
+            .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
+    }
+
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
         List<RoomResponse> roomResponses =
@@ -255,5 +262,12 @@ public class RoomService {
     private void removePlayer(Room room, String sessionId, Player removePlayer) {
         room.removeUserId(removePlayer.getId());
         room.removeSessionId(sessionId);
+    }
+
+    public PlayerListResponse getPlayerListResponse(Long roomId) {
+        Room room = roomRepository.findRoom(roomId)
+            .orElseThrow(() -> new IllegalStateException("방을 찾을 수 없습니다. roomId=" + roomId));
+
+        return toPlayerListResponse(room);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -31,9 +31,9 @@ import io.f1.backend.domain.game.model.RoomState;
 import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
-
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -185,8 +185,9 @@ public class RoomService {
     }
 
     public Player findPlayerInRoomBySessionId(String sessionId, Long roomId) {
-        return roomRepository.findPlayerInRoomBySessionId(sessionId, roomId)
-            .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
+        return roomRepository
+                .findPlayerInRoomBySessionId(sessionId, roomId)
+                .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
     }
 
     public RoomListResponse getAllRooms() {
@@ -265,8 +266,11 @@ public class RoomService {
     }
 
     public PlayerListResponse getPlayerListResponse(Long roomId) {
-        Room room = roomRepository.findRoom(roomId)
-            .orElseThrow(() -> new IllegalStateException("방을 찾을 수 없습니다. roomId=" + roomId));
+        Room room =
+                roomRepository
+                        .findRoom(roomId)
+                        .orElseThrow(
+                                () -> new IllegalStateException("방을 찾을 수 없습니다. roomId=" + roomId));
 
         return toPlayerListResponse(room);
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -35,8 +35,6 @@ import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
-import io.f1.backend.global.exception.CustomException;
-import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -187,8 +185,10 @@ public class RoomService {
     }
 
     public PlayerReadyData handlePlayerReady(Long roomId, String sessionId) {
-        Player player = roomRepository.findPlayerInRoomBySessionId(
-            roomId, sessionId).orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
+        Player player =
+                roomRepository
+                        .findPlayerInRoomBySessionId(roomId, sessionId)
+                        .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
 
         player.toggleReady();
 
@@ -272,5 +272,4 @@ public class RoomService {
         room.removeUserId(removePlayer.getId());
         room.removeSessionId(sessionId);
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/PlayerReadyData.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/PlayerReadyData.java
@@ -2,8 +2,4 @@ package io.f1.backend.domain.game.dto;
 
 import io.f1.backend.domain.game.dto.response.PlayerListResponse;
 
-public record PlayerReadyData(
-    String destination,
-    PlayerListResponse response
-) {
-}
+public record PlayerReadyData(String destination, PlayerListResponse response) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/PlayerReadyData.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/PlayerReadyData.java
@@ -1,0 +1,9 @@
+package io.f1.backend.domain.game.dto;
+
+import io.f1.backend.domain.game.dto.response.PlayerListResponse;
+
+public record PlayerReadyData(
+    String destination,
+    PlayerListResponse response
+) {
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
@@ -1,11 +1,13 @@
 package io.f1.backend.domain.game.store;
 
+import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface RoomRepository {
+
     void saveRoom(Room room);
 
     Optional<Room> findRoom(Long roomId);
@@ -13,4 +15,6 @@ public interface RoomRepository {
     List<Room> findAll();
 
     void removeRoom(Long roomId);
+
+    Optional<Player> findPlayerInRoomBySessionId(String sessionId, Long roomId);
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepository.java
@@ -16,5 +16,5 @@ public interface RoomRepository {
 
     void removeRoom(Long roomId);
 
-    Optional<Player> findPlayerInRoomBySessionId(String sessionId, Long roomId);
+    Optional<Player> findPlayerInRoomBySessionId(Long roomId, String sessionId);
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -37,7 +37,7 @@ public class RoomRepositoryImpl implements RoomRepository {
     }
 
     @Override
-    public Optional<Player> findPlayerInRoomBySessionId(String sessionId, Long roomId) {
+    public Optional<Player> findPlayerInRoomBySessionId(Long roomId, String sessionId) {
         return findRoom(roomId).map(room -> room.getPlayerSessionMap().get(sessionId));
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -3,12 +3,12 @@ package io.f1.backend.domain.game.store;
 import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 
-import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -1,13 +1,14 @@
 package io.f1.backend.domain.game.store;
 
+import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
@@ -33,6 +34,11 @@ public class RoomRepositoryImpl implements RoomRepository {
     @Override
     public void removeRoom(Long roomId) {
         roomMap.remove(roomId);
+    }
+
+    @Override
+    public Optional<Player> findPlayerInRoomBySessionId(String sessionId, Long roomId) {
+        return findRoom(roomId).map(room -> room.getPlayerSessionMap().get(sessionId));
     }
 
     // 테스트 전용 메소드

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
@@ -77,10 +77,11 @@ public class GameSocketController {
     @MessageMapping("/room/ready/{roomId}")
     public void playerReady(@DestinationVariable Long roomId, Message<?> message) {
 
-        PlayerReadyData playerReadyData = roomService.handlePlayerReady(roomId, getSessionId(message));
+        PlayerReadyData playerReadyData =
+                roomService.handlePlayerReady(roomId, getSessionId(message));
 
         messageSender.send(
-            playerReadyData.destination(), MessageType.PLAYER_LIST, playerReadyData.response());
+                playerReadyData.destination(), MessageType.PLAYER_LIST, playerReadyData.response());
     }
 
     private static String getSessionId(Message<?> message) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
@@ -2,6 +2,7 @@ package io.f1.backend.domain.game.websocket;
 
 import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.MessageType;
+import io.f1.backend.domain.game.dto.PlayerReadyData;
 import io.f1.backend.domain.game.dto.RoomExitData;
 import io.f1.backend.domain.game.dto.RoomInitialData;
 import io.f1.backend.domain.game.dto.response.PlayerListResponse;
@@ -61,17 +62,11 @@ public class GameSocketController {
 
     @MessageMapping("/room/ready/{roomId}")
     public void playerReady(@DestinationVariable Long roomId, Message<?> message) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-        String sessionId = accessor.getSessionId();
 
-        Player player = roomService.findPlayerInRoomBySessionId(sessionId, roomId);
+        PlayerReadyData playerReadyData = roomService.handlePlayerReady(roomId, getSessionId(message));
 
-        player.toggleReady();
-
-        PlayerListResponse response = roomService.getPlayerListResponse(roomId);
-
-        String destination = "/sub/room/" + roomId;
-        messageSender.send(destination, MessageType.PLAYER_LIST, response);
+        messageSender.send(
+            playerReadyData.destination(), MessageType.PLAYER_LIST, playerReadyData.response());
     }
 
     private static String getSessionId(Message<?> message) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
@@ -4,9 +4,9 @@ import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.RoomExitData;
 import io.f1.backend.domain.game.dto.RoomInitialData;
-
 import io.f1.backend.domain.game.dto.response.PlayerListResponse;
 import io.f1.backend.domain.game.model.Player;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.messaging.Message;

--- a/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
@@ -4,12 +4,22 @@ import io.f1.backend.domain.user.app.UserService;
 import io.f1.backend.domain.user.dto.SignupRequestDto;
 import io.f1.backend.domain.user.dto.SignupResponseDto;
 
+import io.f1.backend.domain.user.dto.TestLoginRequest;
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import io.f1.backend.domain.user.entity.User;
+import io.f1.backend.global.util.SecurityUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,5 +35,25 @@ public class SignupController {
             @RequestBody SignupRequestDto signupRequest, HttpSession httpSession) {
         SignupResponseDto response = userService.signup(httpSession, signupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/test-login")
+    public String loginForTest(@RequestBody TestLoginRequest request, HttpServletRequest httpRequest) {
+
+        User user = new User();
+        user.setId(request.userId());
+        user.setNickname(request.nickname());
+
+        // SecurityUtils에 위임
+        SecurityUtils.setAuthentication(user);
+
+        HttpSession session = httpRequest.getSession(true);
+        session.setAttribute(
+            HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+            SecurityContextHolder.getContext()
+        );
+        session.setAttribute("user", user);
+
+        return "로그인 성공";
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/SignupController.java
@@ -26,5 +26,4 @@ public class SignupController {
         SignupResponse response = userService.signup(httpSession, signupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
@@ -11,7 +11,8 @@ public enum RoomErrorCode implements ErrorCode {
     ROOM_USER_LIMIT_REACHED("E403002", HttpStatus.FORBIDDEN, "정원이 모두 찼습니다."),
     ROOM_GAME_IN_PROGRESS("E403003", HttpStatus.FORBIDDEN, "게임이 진행 중 입니다."),
     ROOM_NOT_FOUND("E404005", HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
-    WRONG_PASSWORD("E401006", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지않습니다.");
+    WRONG_PASSWORD("E401006", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지않습니다."),
+    PLAYER_NOT_FOUND("E404007", HttpStatus.NOT_FOUND, "존재하지 않는 플레이어입니다.");
 
     private final String code;
 


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #50 

## 🪐 작업 내용

- 플레이어의 레디 상태 변경 기능을 추가했습니다.
- `/room/ready/{roomId}`으로 메시지를 SEND할 때마다 사용자의 isReady상태가 토글되고, 해당 방의 구독자들에게 브로드캐스팅 됩니다.


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?