### PR TITLE
[fix] CORS 경로 설정, HTTPS 환경설정

### DIFF
--- a/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
@@ -12,8 +12,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.addAllowedOrigin("http://localhost:3000"); // 개발 환경
-        config.addAllowedOrigin("http://brainrace.duckdns.org"); // 배포 환경
+        config.addAllowedOrigin("https://brainrace.duckdns.org");
 
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
@@ -12,7 +12,9 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.addAllowedOriginPattern("*");
+        config.addAllowedOrigin("http://localhost:3000"); // 개발 환경
+        config.addAllowedOrigin("http://brainrace.duckdns.org"); // 배포 환경
+
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.setAllowCredentials(true);

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -55,6 +55,10 @@ public class SecurityConfig {
                                         .hasRole("ADMIN")
                                         .requestMatchers("/auth/me")
                                         .hasAnyRole("USER", "ADMIN")
+                                        .requestMatchers("/quizzes/**")
+                                        .hasAnyRole("USER", "ADMIN")
+                                        .requestMatchers("/questions/**")
+                                        .hasAnyRole("USER", "ADMIN")
                                         .anyRequest()
                                         .authenticated())
                 .formLogin(

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -47,7 +48,8 @@ public class SecurityConfig {
                                                 "/js/**",
                                                 "/admin/login")
                                         .permitAll()
-                                        .requestMatchers("/ws/**")
+                                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                                    .requestMatchers("/ws/**")
                                         .authenticated()
                                         .requestMatchers("/user/me")
                                         .hasRole("USER")

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -48,8 +48,9 @@ public class SecurityConfig {
                                                 "/js/**",
                                                 "/admin/login")
                                         .permitAll()
-                                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                    .requestMatchers("/ws/**")
+                                        .requestMatchers(HttpMethod.OPTIONS, "/**")
+                                        .permitAll()
+                                        .requestMatchers("/ws/**")
                                         .authenticated()
                                         .requestMatchers("/user/me")
                                         .hasRole("USER")

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -27,7 +27,7 @@ public class SecurityUtils {
     }
 
     public static UserPrincipal getCurrentUserPrincipal() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = getAuthentication();
         if (authentication != null
                 && authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
             return userPrincipal;
@@ -55,7 +55,7 @@ public class SecurityUtils {
     }
 
     public static AdminPrincipal getCurrentAdminPrincipal() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = getAuthentication();
         if (authentication != null
                 && authentication.getPrincipal() instanceof AdminPrincipal adminPrincipal) {
             return adminPrincipal;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -59,5 +59,7 @@ server:
   servlet:
     session:
       cookie:
+        same-site: None
+        secure: true
         http-only: true
-      timeout: 1800
+      timeout: 60


### PR DESCRIPTION
## 🛰️ Issue Number
- #70 

## 🪐 작업 내용
- 요청 시 쿠키에 JSESSIONID가 세팅이 안되는 문제 발생하여 프론트엔드 도메인 명시적으로 설정했습니다.
- quiz, question API에 대한 요청 권한을 설정 설정했습니다.
- 프론트엔드, 백엔드 배포 환경에 https가 적용이 되고, 서버에서도 same-site: None, secure: true 설정이 되면 로컬 테스트 환경인 http://localhost:3000에서 요청을 보내도 쿠키 전송이 무시된다고 합니다. 그래서 CORS 설정에서 해당 origin은 제거했습니다.


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?