### PR TITLE
[feat] 관리자 퀴즈 수정, 삭제 로직 추가 + User 하드코딩 삭제

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -12,14 +12,15 @@ import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.QuestionErrorCode;
-
 import io.f1.backend.global.security.enums.Role;
 import io.f1.backend.global.util.SecurityUtils;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +52,6 @@ public class QuestionService {
                         .orElseThrow(
                                 () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
-
         verifyUserAuthority(question.getQuiz());
 
         TextQuestion textQuestion = question.getTextQuestion();
@@ -59,7 +59,7 @@ public class QuestionService {
     }
 
     private static void verifyUserAuthority(Quiz quiz) {
-        if(SecurityUtils.getCurrentUserRole() == Role.USER) {
+        if (SecurityUtils.getCurrentUserRole() == Role.USER) {
             validateOwner(quiz.getCreator().getId());
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -59,13 +59,10 @@ public class QuestionService {
     }
 
     private static void verifyUserAuthority(Quiz quiz) {
-        if (SecurityUtils.getCurrentUserRole() == Role.USER) {
-            validateOwner(quiz.getCreator().getId());
+        if (SecurityUtils.getCurrentUserRole() == Role.ADMIN) {
+            return;
         }
-    }
-
-    private static void validateOwner(Long creatorId) {
-        if (!Objects.equals(SecurityUtils.getCurrentUserId(), creatorId)) {
+        if (!Objects.equals(SecurityUtils.getCurrentUserId(), quiz.getCreator().getId())) {
             throw new CustomException(AuthErrorCode.FORBIDDEN);
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -20,6 +20,10 @@ import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.QuizErrorCode;
 
+import io.f1.backend.global.exception.errorcode.UserErrorCode;
+import io.f1.backend.global.security.enums.Role;
+import io.f1.backend.global.util.SecurityUtils;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -52,7 +56,6 @@ public class QuizService {
     private final String DEFAULT = "default";
     private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
-    // TODO : 시큐리티 구현 이후 삭제해도 되는 의존성 주입
     private final UserRepository userRepository;
     private final QuestionService questionService;
     private final QuizRepository quizRepository;
@@ -66,10 +69,11 @@ public class QuizService {
             thumbnailPath = convertToThumbnailPath(thumbnailFile);
         }
 
-        // TODO : 시큐리티 구현 이후 삭제 (data.sql로 초기 저장해둔 유저 get), 나중엔 현재 로그인한 유저의 아이디를 받아오도록 수정
-        User user = userRepository.findById(1L).orElseThrow(RuntimeException::new);
+        Long creatorId = SecurityUtils.getCurrentUserId();
+        User creator = userRepository.findById(creatorId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
-        Quiz quiz = quizCreateRequestToQuiz(request, thumbnailPath, user);
+        Quiz quiz = quizCreateRequestToQuiz(request, thumbnailPath, creator);
 
         Quiz savedQuiz = quizRepository.save(quiz);
 
@@ -125,13 +129,22 @@ public class QuizService {
                         .findById(quizId)
                         .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
-        // TODO : util 메서드에서 사용자 ID 꺼내쓰는 식으로 수정하기
-        if (1L != quiz.getCreator().getId()) {
-            throw new CustomException(AuthErrorCode.FORBIDDEN);
-        }
+        verifyUserAuthority(quiz);
 
         deleteThumbnailFile(quiz.getThumbnailUrl());
         quizRepository.deleteById(quizId);
+    }
+
+    private static void verifyUserAuthority(Quiz quiz) {
+        if(SecurityUtils.getCurrentUserRole() == Role.USER) {
+            validateOwner(quiz.getCreator().getId());
+        }
+    }
+
+    private static void validateOwner(Long creatorId) {
+        if (!Objects.equals(SecurityUtils.getCurrentUserId(), creatorId)) {
+            throw new CustomException(AuthErrorCode.FORBIDDEN);
+        }
     }
 
     @Transactional
@@ -140,6 +153,8 @@ public class QuizService {
                 quizRepository
                         .findById(quizId)
                         .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+
+        verifyUserAuthority(quiz);
 
         validateTitle(title);
         quiz.changeTitle(title);
@@ -153,6 +168,8 @@ public class QuizService {
                         .findById(quizId)
                         .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
+        verifyUserAuthority(quiz);
+
         validateDesc(description);
         quiz.changeDescription(description);
     }
@@ -164,6 +181,8 @@ public class QuizService {
                 quizRepository
                         .findById(quizId)
                         .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+
+        verifyUserAuthority(quiz);
 
         validateImageFile(thumbnailFile);
         String newThumbnailPath = convertToThumbnailPath(thumbnailFile);
@@ -256,8 +275,6 @@ public class QuizService {
                 .findById(quizId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
-        List<Question> randomQuestions = quizRepository.findRandQuestionsByQuizId(quizId, round);
-
-        return randomQuestions;
+        return quizRepository.findRandQuestionsByQuizId(quizId, round);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -19,11 +19,10 @@ import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.QuizErrorCode;
-
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 import io.f1.backend.global.security.enums.Role;
 import io.f1.backend.global.util.SecurityUtils;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -70,8 +70,10 @@ public class QuizService {
         }
 
         Long creatorId = SecurityUtils.getCurrentUserId();
-        User creator = userRepository.findById(creatorId)
-            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        User creator =
+                userRepository
+                        .findById(creatorId)
+                        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         Quiz quiz = quizCreateRequestToQuiz(request, thumbnailPath, creator);
 
@@ -136,7 +138,7 @@ public class QuizService {
     }
 
     private static void verifyUserAuthority(Quiz quiz) {
-        if(SecurityUtils.getCurrentUserRole() == Role.USER) {
+        if (SecurityUtils.getCurrentUserRole() == Role.USER) {
             validateOwner(quiz.getCreator().getId());
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -138,13 +138,10 @@ public class QuizService {
     }
 
     private static void verifyUserAuthority(Quiz quiz) {
-        if (SecurityUtils.getCurrentUserRole() == Role.USER) {
-            validateOwner(quiz.getCreator().getId());
+        if (SecurityUtils.getCurrentUserRole() == Role.ADMIN) {
+            return;
         }
-    }
-
-    private static void validateOwner(Long creatorId) {
-        if (!Objects.equals(SecurityUtils.getCurrentUserId(), creatorId)) {
+        if (!Objects.equals(SecurityUtils.getCurrentUserId(), quiz.getCreator().getId())) {
             throw new CustomException(AuthErrorCode.FORBIDDEN);
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -26,8 +26,7 @@ public class QuizMapper {
                 quizCreateRequest.getDescription(),
                 quizCreateRequest.getQuizType(),
                 imgUrl,
-                creator
-                );
+                creator);
     }
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {

--- a/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/mapper/QuizMapper.java
@@ -18,21 +18,19 @@ import java.util.List;
 
 public class QuizMapper {
 
-    // TODO : 이후 파라미터에서 user 삭제하기
     public static Quiz quizCreateRequestToQuiz(
-            QuizCreateRequest quizCreateRequest, String imgUrl, User user) {
+            QuizCreateRequest quizCreateRequest, String imgUrl, User creator) {
 
         return new Quiz(
                 quizCreateRequest.getTitle(),
                 quizCreateRequest.getDescription(),
                 quizCreateRequest.getQuizType(),
                 imgUrl,
-                user // TODO : 이후 creator에 들어갈 User은 현재 로그인 중인 유저를 가져오도록 변경
+                creator
                 );
     }
 
     public static QuizCreateResponse quizToQuizCreateResponse(Quiz quiz) {
-        // TODO : creatorId 넣어주는 부분에서 Getter를 안 쓰고, 현재 로그인한 유저의 id를 담는 식으로 바꿔도 될 듯
         return new QuizCreateResponse(
                 quiz.getId(),
                 quiz.getTitle(),

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -5,8 +5,8 @@ import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.AuthErrorCode;
-
 import io.f1.backend.global.security.enums.Role;
+
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
+++ b/backend/src/main/java/io/f1/backend/global/util/SecurityUtils.java
@@ -6,6 +6,7 @@ import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 
+import io.f1.backend.global.security.enums.Role;
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -41,6 +42,15 @@ public class SecurityUtils {
 
     public static String getCurrentUserNickname() {
         return getCurrentUserPrincipal().getUserNickname();
+    }
+
+    public static Role getCurrentUserRole() {
+        Authentication authentication = getAuthentication();
+        if (authentication != null
+                && authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
+            return Role.USER;
+        }
+        return Role.ADMIN;
     }
 
     public static void logout(HttpSession session) {


### PR DESCRIPTION
## 🛰️ Issue Number
- #36 

## 🪐 작업 내용
### 1. User 하드 코딩 삭제 
- 다만, `data.sql`은 이후 FE 개발자님도 퀴즈 생성 때문에 사용하시는 것 같아서 지우지 않았습니다.
- User 정보는 `SecurityUtils.getCurrentUserId`를 통해 받아오도록 수정했습니다.

### 2. 관리자 퀴즈 수정, 삭제 로직 추가
- 관리자일 때 : 퀴즈 수정, 삭제 가능 / 문제 수정, 삭제 가능
- 사용자일 때 : 퀴즈의 creator가 현재 로그인한 유저와 같은지 비교 후 -> 같다면 수정, 삭제 가능

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?