### PR TITLE
feat: PR Open 시 Slack 알림 Github Action 추가

### DIFF
--- a/.github/workflows/slack-notify-pr-open.yml
+++ b/.github/workflows/slack-notify-pr-open.yml
@@ -1,0 +1,22 @@
+name: slack-notify-pr-open
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: Github CI
+          SLACK_ICON: https://github.com/github.png
+          SLACK_COLOR: '#36a64f'
+          SLACK_TITLE: 'New Pull Request 🚀'
+          SLACK_MESSAGE: |
+            🚧 PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
+            created by ${{ github.actor }}
+            🔗 ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/slack-notify-pr-open.yml
+++ b/.github/workflows/slack-notify-pr-open.yml
@@ -15,8 +15,7 @@ jobs:
           SLACK_USERNAME: Github CI
           SLACK_ICON: https://github.com/github.png
           SLACK_COLOR: '#36a64f'
-          SLACK_TITLE: 'New Pull Request 🚀'
+          SLACK_TITLE: 'New Pull Request'
           SLACK_MESSAGE: |
-            🚧 PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
-            created by ${{ github.actor }}
+            #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
             🔗 ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/slack-notify-pr-open.yml
+++ b/.github/workflows/slack-notify-pr-open.yml
@@ -16,7 +16,7 @@ jobs:
           SLACK_ICON: https://github.com/github.png
           MSG_MINIMAL: ref,event
           SLACK_COLOR: '#36a64f'
-          SLACK_TITLE: 'New Pull Request'
+          SLACK_TITLE: 'New Pull Request 🚀'
           SLACK_MESSAGE: |
             #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
             🔗 ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/slack-notify-pr-open.yml
+++ b/.github/workflows/slack-notify-pr-open.yml
@@ -14,6 +14,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: Github CI
           SLACK_ICON: https://github.com/github.png
+          MSG_MINIMAL: ref,event
           SLACK_COLOR: '#36a64f'
           SLACK_TITLE: 'New Pull Request'
           SLACK_MESSAGE: |


### PR DESCRIPTION
## 🛰️ Issue Number
- #80 

## 🪐 작업 내용
- PR Open 시 Slack에 알림을 주는 Github Action을 추가합니다.

## 📚 Reference
[action-slack-notify](https://github.com/rtCamp/action-slack-notify?tab=readme-ov-file)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?