### PR TITLE
[refactor] 게임 시작 요청 리팩토링

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -13,6 +13,7 @@ import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.GameErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -68,7 +69,7 @@ public class GameService {
         }
 
         if (!validateReadyStatus(room)) {
-            throw new CustomException(RoomErrorCode.PLAYER_NOT_READY);
+            throw new CustomException(GameErrorCode.PLAYER_NOT_READY);
         }
 
         if (room.getState() == RoomState.PLAYING) {
@@ -77,7 +78,7 @@ public class GameService {
     }
 
     // 라운드 수만큼 랜덤 Question 추출
-    public List<Question> prepareQuestions(Room room, Quiz quiz) {
+    private List<Question> prepareQuestions(Room room, Quiz quiz) {
         Long quizId = quiz.getId();
         Integer round = room.getGameSetting().getRound();
         return quizService.getRandomQuestionsWithoutAnswer(quizId, round);

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -2,10 +2,8 @@ package io.f1.backend.domain.game.app;
 
 import static io.f1.backend.domain.quiz.mapper.QuizMapper.toGameStartResponse;
 
-import io.f1.backend.domain.game.dto.request.GameStartRequest;
 import io.f1.backend.domain.game.dto.response.GameStartResponse;
 import io.f1.backend.domain.game.event.RoomUpdatedEvent;
-import io.f1.backend.domain.game.model.GameSetting;
 import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.model.RoomState;
@@ -17,7 +15,6 @@ import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -25,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -13,10 +13,11 @@ import io.f1.backend.domain.game.store.RoomRepository;
 import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.quiz.app.QuizService;
 import io.f1.backend.domain.quiz.entity.Quiz;
+import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.exception.CustomException;
-import io.f1.backend.global.exception.errorcode.GameErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -33,47 +34,27 @@ public class GameService {
     private final RoomRepository roomRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public GameStartResponse gameStart(Long roomId, GameStartRequest gameStartRequest) {
-
-        Long quizId = gameStartRequest.quizId();
+    public GameStartResponse gameStart(Long roomId, UserPrincipal principal) {
 
         Room room =
                 roomRepository
                         .findRoom(roomId)
                         .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
 
-        if (!validateReadyStatus(room)) {
-            throw new CustomException(RoomErrorCode.PLAYER_NOT_READY);
-        }
+        validateRoomStart(room, principal);
 
-        // 방의 gameSetting에 설정된 퀴즈랑 요청 퀴즈랑 같은지 체크 후 GameSetting에서 라운드 가져오기
-        Integer round = checkGameSetting(room, quizId);
-
+        Long quizId = room.getGameSetting().getQuizId();
         Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+        List<Question> questions = prepareQuestions(room, quiz);
 
-        // 라운드 수만큼 랜덤 Question 추출
-        List<Question> questions = quizService.getRandomQuestionsWithoutAnswer(quizId, round);
         room.updateQuestions(questions);
-
-        GameStartResponse gameStartResponse = toGameStartResponse(questions);
 
         // 방 정보 게임 중으로 변경
         room.updateRoomState(RoomState.PLAYING);
 
         eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz));
 
-        return gameStartResponse;
-    }
-
-    private Integer checkGameSetting(Room room, Long quizId) {
-
-        GameSetting gameSetting = room.getGameSetting();
-
-        if (!gameSetting.validateQuizId(quizId)) {
-            throw new CustomException(GameErrorCode.GAME_SETTING_CONFLICT);
-        }
-
-        return gameSetting.getRound();
+        return toGameStartResponse(questions);
     }
 
     private boolean validateReadyStatus(Room room) {
@@ -81,5 +62,26 @@ public class GameService {
         Map<String, Player> playerSessionMap = room.getPlayerSessionMap();
 
         return playerSessionMap.values().stream().allMatch(Player::isReady);
+    }
+
+    private void validateRoomStart(Room room, UserPrincipal principal) {
+        if (!Objects.equals(principal.getUserId(), room.getHost().getId())) {
+            throw new CustomException(RoomErrorCode.NOT_ROOM_OWNER);
+        }
+
+        if (!validateReadyStatus(room)) {
+            throw new CustomException(RoomErrorCode.PLAYER_NOT_READY);
+        }
+
+        if (room.getState() == RoomState.PLAYING) {
+            throw new CustomException(RoomErrorCode.GAME_ALREADY_PLAYING);
+        }
+    }
+
+    // 라운드 수만큼 랜덤 Question 추출
+    public List<Question> prepareQuestions(Room room, Quiz quiz) {
+        Long quizId = quiz.getId();
+        Integer round = room.getGameSetting().getRound();
+        return quizService.getRandomQuestionsWithoutAnswer(quizId, round);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/GameStartRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/GameStartRequest.java
@@ -1,3 +1,0 @@
-package io.f1.backend.domain.game.dto.request;
-
-public record GameStartRequest(Long quizId) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/GameSocketController.java
@@ -1,5 +1,8 @@
 package io.f1.backend.domain.game.websocket;
 
+import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionId;
+import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionUser;
+
 import io.f1.backend.domain.game.app.GameService;
 import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.ChatMessage;
@@ -18,9 +21,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
-
-import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionId;
-import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionUser;
 
 @Controller
 @RequiredArgsConstructor
@@ -71,8 +71,7 @@ public class GameSocketController {
     }
 
     @MessageMapping("/room/start/{roomId}")
-    public void gameStart(
-            @DestinationVariable Long roomId, Message<?> message) {
+    public void gameStart(@DestinationVariable Long roomId, Message<?> message) {
 
         UserPrincipal principal = getSessionUser(message);
 

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/WebSocketUtils.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/WebSocketUtils.java
@@ -1,0 +1,20 @@
+package io.f1.backend.domain.game.websocket;
+
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
+
+public class WebSocketUtils {
+
+    public static String getSessionId(Message<?> message) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        return accessor.getSessionId();
+    }
+
+    public static UserPrincipal getSessionUser(Message<?> message) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        Authentication auth = (Authentication) accessor.getUser();
+        return (UserPrincipal) auth.getPrincipal();
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/WebSocketUtils.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/WebSocketUtils.java
@@ -1,6 +1,7 @@
 package io.f1.backend.domain.game.websocket;
 
 import io.f1.backend.domain.user.dto.UserPrincipal;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.Authentication;

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/GameErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/GameErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum GameErrorCode implements ErrorCode {
-    GAME_SETTING_CONFLICT("E409002", HttpStatus.CONFLICT, "게임 설정이 맞지 않습니다.");
+    GAME_SETTING_CONFLICT("E409002", HttpStatus.CONFLICT, "게임 설정이 맞지 않습니다."),
+    PLAYER_NOT_READY("E403004", HttpStatus.FORBIDDEN, "게임 시작을 위한 준비 상태가 아닙니다.");
 
     private final String code;
 

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 public enum RoomErrorCode implements ErrorCode {
     ROOM_USER_LIMIT_REACHED("E403002", HttpStatus.FORBIDDEN, "정원이 모두 찼습니다."),
     ROOM_GAME_IN_PROGRESS("E403003", HttpStatus.FORBIDDEN, "게임이 진행 중 입니다."),
-    PLAYER_NOT_READY("E403004", HttpStatus.FORBIDDEN, "게임 시작을 위한 준비 상태가 아닙니다."),
     ROOM_NOT_FOUND("E404005", HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
     WRONG_PASSWORD("E401006", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지않습니다."),
     PLAYER_NOT_FOUND("E404007", HttpStatus.NOT_FOUND, "존재하지 않는 플레이어입니다."),

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/RoomErrorCode.java
@@ -14,7 +14,9 @@ public enum RoomErrorCode implements ErrorCode {
     ROOM_NOT_FOUND("E404005", HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
     WRONG_PASSWORD("E401006", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지않습니다."),
     PLAYER_NOT_FOUND("E404007", HttpStatus.NOT_FOUND, "존재하지 않는 플레이어입니다."),
-    SOCKET_SESSION_NOT_FOUND("E404006", HttpStatus.NOT_FOUND, "존재하지 않는 소켓 세션입니다.");
+    SOCKET_SESSION_NOT_FOUND("E404006", HttpStatus.NOT_FOUND, "존재하지 않는 소켓 세션입니다."),
+    GAME_ALREADY_PLAYING("E400015", HttpStatus.BAD_REQUEST, "이미 게임이 진행 중 입니다."),
+    NOT_ROOM_OWNER("E403005", HttpStatus.FORBIDDEN, "방장만 게임 시작이 가능합니다.");
 
     private final String code;
 


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #74 

## 🪐 작업 내용
### 게임 시작 요청 리팩토링 내용
- 게임 시작의 요청 메시지를 제거했습니다. `type`과 `message`모두 없습니다.
- 게임 시작에 문제가 될 수 있는 부분들을 추가하고 예외처리하였습니다. 아래는 추가된 예외입니다.
    1. 방장이 아닌 사람이 게임을 시작하는 경우 [**ErrorCode** : E403005, message: "방장만 게임 시작이 가능합니다."]
    2.  이미 게임 진행 중에 또 게임 시작을 하는 경우 [**ErrorCode** : E400015, message: "이미 게임이 진행 중 입니다."]

- gameStart의 예외처리가 많아져서 메서드로 분리했습니다.
### WebSocketUtils 클래스 분리
- GameSocketController에 존재하던 getSessionId()와 getSessionUser를 유틸클래스로 옮겨놓았습니다.

### 알게된 점
- 저만 바보여서 몰랐을 수 도 있지만... 웹소켓은 HTTP요청 기반의 통신이 아니므로, @AuthenticationPrincipal로 UserPrincipal을 @MessageMapping의 인자로 직접 주입받는 것이 불가능합니다.

- Spring Security는 인증 정보를 SecurityContextHolder의 ThreadLocal에 저장하는 방식인데, WebSocket 메시지 처리는 다른 쓰레드에서 이루어지기 때문에 기존의 인증 정보가 공유되지 않습니다.
- 
-  그래서, 매번 SEND마다 컨텍스트홀더에 인증 정보를 수동으로 계속 주입해줘야 하는... 마치 밥을 한 숟가락 먹을때마다, 밥을 새로 짓는듯한.... 아주 비효율의 끝판왕을 제가 하고 있었습니다. 그래서 기존 방식대로 accessor로 웹소켓세션의 어트리뷰트에 접근하는 방식(WebSocktUtils 사용)으로 유지되면 될 것 같습니다.

**+** 나중에 리마인드를 위해 추가로 적어놓았습니다!
- `@AuthenticationPrincipal`은 HTTP 요청에서 SecurityContextHolder에 저장된 인증 객체를 기반으로 스프링이 자동 주입해주는 기능


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?