### PR TITLE
[refactor] 퀴즈 정보 조회 메서드 수정

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -110,7 +110,7 @@ public class RoomService {
             }
 
             if (room.getRoomSetting().locked()
-                && !room.getRoomSetting().password().equals(request.password())) {
+                    && !room.getRoomSetting().password().equals(request.password())) {
                 throw new CustomException(RoomErrorCode.WRONG_PASSWORD);
             }
 
@@ -119,7 +119,7 @@ public class RoomService {
     }
 
     public RoomInitialData initializeRoomSocket(
-        Long roomId, String sessionId, UserPrincipal principal) {
+            Long roomId, String sessionId, UserPrincipal principal) {
 
         Room room = findRoom(roomId);
 
@@ -145,15 +145,15 @@ public class RoomService {
         Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
         GameSettingResponse gameSettingResponse =
-            toGameSettingResponse(room.getGameSetting(), quiz);
+                toGameSettingResponse(room.getGameSetting(), quiz);
 
         PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
         SystemNoticeResponse systemNoticeResponse =
-            ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
+                ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
 
         return new RoomInitialData(
-            roomSettingResponse, gameSettingResponse, playerListResponse, systemNoticeResponse);
+                roomSettingResponse, gameSettingResponse, playerListResponse, systemNoticeResponse);
     }
 
     public RoomExitData exitRoom(Long roomId, String sessionId, UserPrincipal principal) {
@@ -179,7 +179,7 @@ public class RoomService {
             removePlayer(room, sessionId, removePlayer);
 
             SystemNoticeResponse systemNoticeResponse =
-                ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
+                    ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
 
             PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
@@ -189,9 +189,9 @@ public class RoomService {
 
     public PlayerListResponse handlePlayerReady(Long roomId, String sessionId) {
         Player player =
-            roomRepository
-                .findPlayerInRoomBySessionId(roomId, sessionId)
-                .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
+                roomRepository
+                        .findPlayerInRoomBySessionId(roomId, sessionId)
+                        .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
 
         player.toggleReady();
 
@@ -203,15 +203,15 @@ public class RoomService {
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
         List<RoomResponse> roomResponses =
-            rooms.stream()
-                .map(
-                    room -> {
-                        Long quizId = room.getGameSetting().getQuizId();
-                        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+                rooms.stream()
+                        .map(
+                                room -> {
+                                    Long quizId = room.getGameSetting().getQuizId();
+                                    Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                        return toRoomResponse(room, quiz);
-                    })
-                .toList();
+                                    return toRoomResponse(room, quiz);
+                                })
+                        .toList();
         return new RoomListResponse(roomResponses);
     }
 
@@ -234,12 +234,12 @@ public class RoomService {
         room.increasePlayerCorrectCount(sessionId);
 
         return RoundResult.builder()
-            .questionResult(
-                toQuestionResultResponse(currentQuestion.getId(), chatMessage, answer))
-            .rankUpdate(toRankUpdateResponse(room))
-            .systemNotice(ofPlayerEvent(chatMessage.nickname(), RoomEventType.ENTER))
-            .chat(chatMessage)
-            .build();
+                .questionResult(
+                        toQuestionResultResponse(currentQuestion.getId(), chatMessage, answer))
+                .rankUpdate(toRankUpdateResponse(room))
+                .systemNotice(ofPlayerEvent(chatMessage.nickname(), RoomEventType.ENTER))
+                .chat(chatMessage)
+                .build();
     }
 
     private Player getRemovePlayer(Room room, String sessionId, UserPrincipal principal) {
@@ -261,8 +261,8 @@ public class RoomService {
 
     private Room findRoom(Long roomId) {
         return roomRepository
-            .findRoom(roomId)
-            .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
+                .findRoom(roomId)
+                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
     }
 
     private boolean isLastPlayer(Room room, String sessionId) {
@@ -282,14 +282,14 @@ public class RoomService {
         Map<String, Player> playerSessionMap = room.getPlayerSessionMap();
 
         Optional<String> nextHostSessionId =
-            playerSessionMap.keySet().stream()
-                .filter(key -> !key.equals(hostSessionId))
-                .findFirst();
+                playerSessionMap.keySet().stream()
+                        .filter(key -> !key.equals(hostSessionId))
+                        .findFirst();
 
         Player nextHost =
-            playerSessionMap.get(
-                nextHostSessionId.orElseThrow(
-                    () -> new CustomException(RoomErrorCode.SOCKET_SESSION_NOT_FOUND)));
+                playerSessionMap.get(
+                        nextHostSessionId.orElseThrow(
+                                () -> new CustomException(RoomErrorCode.SOCKET_SESSION_NOT_FOUND)));
 
         room.updateHost(nextHost);
         log.info("user_id:{} 방장 변경 완료 ", nextHost.getId());

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -122,9 +122,9 @@ public class QuizService {
     public void deleteQuiz(Long quizId) {
 
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         // TODO : util 메서드에서 사용자 ID 꺼내쓰는 식으로 수정하기
         if (1L != quiz.getCreator().getId()) {
@@ -138,9 +138,9 @@ public class QuizService {
     @Transactional
     public void updateQuizTitle(Long quizId, String title) {
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateTitle(title);
         quiz.changeTitle(title);
@@ -150,9 +150,9 @@ public class QuizService {
     public void updateQuizDesc(Long quizId, String description) {
 
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateDesc(description);
         quiz.changeDescription(description);
@@ -162,9 +162,9 @@ public class QuizService {
     public void updateThumbnail(Long quizId, MultipartFile thumbnailFile) {
 
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateImageFile(thumbnailFile);
         String newThumbnailPath = convertToThumbnailPath(thumbnailFile);
@@ -230,9 +230,9 @@ public class QuizService {
     @Transactional(readOnly = true)
     public Quiz getQuizWithQuestionsById(Long quizId) {
         Quiz quiz =
-            quizRepository
-                .findQuizWithQuestionsById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findQuizWithQuestionsById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
         return quiz;
     }
 
@@ -244,9 +244,9 @@ public class QuizService {
     @Transactional(readOnly = true)
     public QuizQuestionListResponse getQuizWithQuestions(Long quizId) {
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         return quizToQuizQuestionListResponse(quiz);
     }
@@ -254,8 +254,8 @@ public class QuizService {
     @Transactional(readOnly = true)
     public List<Question> getRandomQuestionsWithoutAnswer(Long quizId, Integer round) {
         quizRepository
-            .findById(quizId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+                .findById(quizId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         List<Question> randomQuestions = quizRepository.findRandQuestionsByQuizId(quizId, round);
 
@@ -264,7 +264,8 @@ public class QuizService {
 
     @Transactional(readOnly = true)
     public Quiz findQuizById(Long quizId) {
-        return quizRepository.findById(quizId)
-            .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+        return quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -122,9 +122,9 @@ public class QuizService {
     public void deleteQuiz(Long quizId) {
 
         Quiz quiz =
-                quizRepository
-                        .findById(quizId)
-                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         // TODO : util 메서드에서 사용자 ID 꺼내쓰는 식으로 수정하기
         if (1L != quiz.getCreator().getId()) {
@@ -138,9 +138,9 @@ public class QuizService {
     @Transactional
     public void updateQuizTitle(Long quizId, String title) {
         Quiz quiz =
-                quizRepository
-                        .findById(quizId)
-                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateTitle(title);
         quiz.changeTitle(title);
@@ -150,9 +150,9 @@ public class QuizService {
     public void updateQuizDesc(Long quizId, String description) {
 
         Quiz quiz =
-                quizRepository
-                        .findById(quizId)
-                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateDesc(description);
         quiz.changeDescription(description);
@@ -162,9 +162,9 @@ public class QuizService {
     public void updateThumbnail(Long quizId, MultipartFile thumbnailFile) {
 
         Quiz quiz =
-                quizRepository
-                        .findById(quizId)
-                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         validateImageFile(thumbnailFile);
         String newThumbnailPath = convertToThumbnailPath(thumbnailFile);
@@ -230,9 +230,9 @@ public class QuizService {
     @Transactional(readOnly = true)
     public Quiz getQuizWithQuestionsById(Long quizId) {
         Quiz quiz =
-                quizRepository
-                        .findQuizWithQuestionsById(quizId)
-                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+            quizRepository
+                .findQuizWithQuestionsById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
         return quiz;
     }
 
@@ -244,9 +244,9 @@ public class QuizService {
     @Transactional(readOnly = true)
     public QuizQuestionListResponse getQuizWithQuestions(Long quizId) {
         Quiz quiz =
-                quizRepository
-                        .findById(quizId)
-                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+            quizRepository
+                .findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         return quizToQuizQuestionListResponse(quiz);
     }
@@ -254,11 +254,17 @@ public class QuizService {
     @Transactional(readOnly = true)
     public List<Question> getRandomQuestionsWithoutAnswer(Long quizId, Integer round) {
         quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
+            .findById(quizId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 퀴즈입니다."));
 
         List<Question> randomQuestions = quizRepository.findRandQuestionsByQuizId(quizId, round);
 
         return randomQuestions;
+    }
+
+    @Transactional(readOnly = true)
+    public Quiz findQuizById(Long quizId) {
+        return quizRepository.findById(quizId)
+            .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #76 

## 🪐 작업 내용
- quizService에 퀴즈 단건 조회 메서드 추가
- roomService에 퀴즈 단건 조회 적용

세희님이 작업하신 #72 와 연관된 작업입니다. QuizMinData에서 퀴즈의 문제수와 함께 quizId를 가져오는데, 그 quizId로 퀴즈의 정보를 SSE메시지에 담아 보내는데 사용됩니다.
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?