### PR TITLE
[feat] 유저 닉네임을 통해 랭킹 조회

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/stat/api/StatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/api/StatController.java
@@ -31,13 +31,12 @@ public class StatController {
         return ResponseEntity.ok().body(response);
     }
 
-	@LimitPageSize
-	@GetMapping("/rankings/{nickname}")
-	public ResponseEntity<StatPageResponse> getRankingsByNickname(
-		@PathVariable String nickname,
-		@PageableDefault Pageable pageable
-	) {
-		StatPageResponse response = statService.getRanksByNickname(nickname, pageable.getPageSize());
-		return ResponseEntity.ok().body(response);
-	}
+    @LimitPageSize
+    @GetMapping("/rankings/{nickname}")
+    public ResponseEntity<StatPageResponse> getRankingsByNickname(
+            @PathVariable String nickname, @PageableDefault Pageable pageable) {
+        StatPageResponse response =
+                statService.getRanksByNickname(nickname, pageable.getPageSize());
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/api/StatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/api/StatController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,4 +30,14 @@ public class StatController {
 
         return ResponseEntity.ok().body(response);
     }
+
+	@LimitPageSize
+	@GetMapping("/rankings/{nickname}")
+	public ResponseEntity<StatPageResponse> getRankingsByNickname(
+		@PathVariable String nickname,
+		@PageableDefault Pageable pageable
+	) {
+		StatPageResponse response = statService.getRanksByNickname(nickname, pageable.getPageSize());
+		return ResponseEntity.ok().body(response);
+	}
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
@@ -5,12 +5,9 @@ import static io.f1.backend.domain.stat.mapper.StatMapper.toStatListPageResponse
 import io.f1.backend.domain.stat.dao.StatRepository;
 import io.f1.backend.domain.stat.dto.StatPageResponse;
 import io.f1.backend.domain.stat.dto.StatWithNickname;
-
 import io.f1.backend.global.exception.CustomException;
-import io.f1.backend.global.exception.errorcode.ErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
@@ -28,28 +25,30 @@ public class StatService {
 
     private final StatRepository statRepository;
 
-	@Transactional(readOnly = true)
+    @Transactional(readOnly = true)
     public StatPageResponse getRanks(Pageable pageable) {
         Page<StatWithNickname> stats = statRepository.findWithUser(pageable);
         return toStatListPageResponse(stats);
     }
 
-	@Transactional(readOnly = true)
-	public StatPageResponse getRanksByNickname(String nickname, int pageSize) {
+    @Transactional(readOnly = true)
+    public StatPageResponse getRanksByNickname(String nickname, int pageSize) {
 
-		Page<StatWithNickname> stats = statRepository.findWithUser(
-			getPageableFromNickname(nickname, pageSize));
+        Page<StatWithNickname> stats =
+                statRepository.findWithUser(getPageableFromNickname(nickname, pageSize));
 
-		return toStatListPageResponse(stats);
-	}
+        return toStatListPageResponse(stats);
+    }
 
-	private Pageable getPageableFromNickname(String nickname, int pageSize) {
-		long score = statRepository.findScoreByNickname(nickname)
-			.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
+    private Pageable getPageableFromNickname(String nickname, int pageSize) {
+        long score =
+                statRepository
+                        .findScoreByNickname(nickname)
+                        .orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
 
-		long rowNum = statRepository.countByScoreGreaterThan(score);
+        long rowNum = statRepository.countByScoreGreaterThan(score);
 
-		int pageNumber = rowNum > 0 ? (int) (rowNum / pageSize) : 0;
-		return PageRequest.of(pageNumber, pageSize, Sort.by(Direction.DESC, "score"));
-	}
+        int pageNumber = rowNum > 0 ? (int) (rowNum / pageSize) : 0;
+        return PageRequest.of(pageNumber, pageSize, Sort.by(Direction.DESC, "score"));
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
@@ -6,20 +6,50 @@ import io.f1.backend.domain.stat.dao.StatRepository;
 import io.f1.backend.domain.stat.dto.StatPageResponse;
 import io.f1.backend.domain.stat.dto.StatWithNickname;
 
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.ErrorCode;
+import io.f1.backend.global.exception.errorcode.RoomErrorCode;
+
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class StatService {
 
     private final StatRepository statRepository;
 
+	@Transactional(readOnly = true)
     public StatPageResponse getRanks(Pageable pageable) {
         Page<StatWithNickname> stats = statRepository.findWithUser(pageable);
         return toStatListPageResponse(stats);
     }
+
+	@Transactional(readOnly = true)
+	public StatPageResponse getRanksByNickname(String nickname, int pageSize) {
+
+		Page<StatWithNickname> stats = statRepository.findWithUser(
+			getPageableFromNickname(nickname, pageSize));
+
+		return toStatListPageResponse(stats);
+	}
+
+	private Pageable getPageableFromNickname(String nickname, int pageSize) {
+		long score = statRepository.findScoreByNickname(nickname)
+			.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND));
+
+		long rowNum = statRepository.countByScoreGreaterThan(score);
+
+		int pageNumber = rowNum > 0 ? (int) (rowNum / pageSize) : 0;
+		return PageRequest.of(pageNumber, pageSize, Sort.by(Direction.DESC, "score"));
+	}
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class StatService {
 

--- a/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/app/StatService.java
@@ -26,7 +26,7 @@ public class StatService {
 
     @Transactional(readOnly = true)
     public StatPageResponse getRanks(Pageable pageable) {
-        Page<StatWithNickname> stats = statRepository.findWithUser(pageable);
+        Page<StatWithNickname> stats = statRepository.findAllStatsWithUser(pageable);
         return toStatListPageResponse(stats);
     }
 
@@ -34,7 +34,7 @@ public class StatService {
     public StatPageResponse getRanksByNickname(String nickname, int pageSize) {
 
         Page<StatWithNickname> stats =
-                statRepository.findWithUser(getPageableFromNickname(nickname, pageSize));
+                statRepository.findAllStatsWithUser(getPageableFromNickname(nickname, pageSize));
 
         return toStatListPageResponse(stats);
     }

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
@@ -3,6 +3,7 @@ package io.f1.backend.domain.stat.dao;
 import io.f1.backend.domain.stat.dto.StatWithNickname;
 import io.f1.backend.domain.stat.entity.Stat;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,4 +20,9 @@ public interface StatRepository extends JpaRepository<Stat, Long> {
             		Stat s JOIN s.user u
             """)
     Page<StatWithNickname> findWithUser(Pageable pageable);
+
+	@Query("SELECT s.score FROM Stat s WHERE s.user.nickname = :nickname")
+	Optional<Long> findScoreByNickname(String nickname);
+
+	long countByScoreGreaterThan(Long score);
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
@@ -20,7 +20,7 @@ public interface StatRepository extends JpaRepository<Stat, Long> {
             FROM
             		Stat s JOIN s.user u
             """)
-    Page<StatWithNickname> findWithUser(Pageable pageable);
+    Page<StatWithNickname> findAllStatsWithUser(Pageable pageable);
 
     @Query("SELECT s.score FROM Stat s WHERE s.user.nickname = :nickname")
     Optional<Long> findScoreByNickname(String nickname);

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
@@ -3,11 +3,12 @@ package io.f1.backend.domain.stat.dao;
 import io.f1.backend.domain.stat.dto.StatWithNickname;
 import io.f1.backend.domain.stat.entity.Stat;
 
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface StatRepository extends JpaRepository<Stat, Long> {
 
@@ -21,8 +22,8 @@ public interface StatRepository extends JpaRepository<Stat, Long> {
             """)
     Page<StatWithNickname> findWithUser(Pageable pageable);
 
-	@Query("SELECT s.score FROM Stat s WHERE s.user.nickname = :nickname")
-	Optional<Long> findScoreByNickname(String nickname);
+    @Query("SELECT s.score FROM Stat s WHERE s.user.nickname = :nickname")
+    Optional<Long> findScoreByNickname(String nickname);
 
-	long countByScoreGreaterThan(Long score);
+    long countByScoreGreaterThan(Long score);
 }

--- a/backend/src/test/java/io/f1/backend/domain/stat/StatBrowserTest.java
+++ b/backend/src/test/java/io/f1/backend/domain/stat/StatBrowserTest.java
@@ -2,12 +2,15 @@ package io.f1.backend.domain.stat;
 
 import static io.f1.backend.global.exception.errorcode.CommonErrorCode.INVALID_PAGINATION;
 
+import static io.f1.backend.global.exception.errorcode.RoomErrorCode.PLAYER_NOT_FOUND;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 
+import io.f1.backend.global.exception.errorcode.ErrorCode;
+import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.template.BrowserTestTemplate;
 
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +38,7 @@ public class StatBrowserTest extends BrowserTestTemplate {
 
     @Test
     @DisplayName("100을 넘는 페이지 크기 요청이 오면 예외를 발생시킨다")
-    void totalRankingForSingleUserWithInvalidPageSize() throws Exception {
+    void totalRankingWithInvalidPageSize() throws Exception {
         // when
         ResultActions result = mockMvc.perform(get("/stats/rankings").param("size", "101"));
 
@@ -86,4 +89,61 @@ public class StatBrowserTest extends BrowserTestTemplate {
                 jsonPath("$.totalElements").value(1),
                 jsonPath("$.ranks.length()").value(1));
     }
+
+	@Test
+	@DataSet("datasets/stat/three-user-stat.yml")
+	@DisplayName("랭킹 페이지에서 존재하지 않는 닉네임을 검색하면 예외를 발생시킨다.")
+	void totalRankingWithUnregisteredNickname() throws Exception {
+		// given
+		String nickname = "UNREGISTERED";
+
+		// when
+		ResultActions result = mockMvc.perform(get("/stats/rankings/" + nickname));
+
+		// then
+		result.andExpectAll(
+			status().isNotFound(), jsonPath("$.code").value(PLAYER_NOT_FOUND.getCode()));
+	}
+
+	@Test
+	@DataSet("datasets/stat/three-user-stat.yml")
+	@DisplayName("총 유저 수가 3명이고 페이지 크기가 2일 때 1위 유저의 닉네임을 검색하면 첫 번째 페이지에 2개의 결과를 반환한다")
+	void totalRankingForThreeUserWithFirstRankedNickname() throws Exception {
+		// given
+		String nickname = "USER3";
+
+		// when
+		ResultActions result = mockMvc.perform(
+			get("/stats/rankings/" + nickname).param("size", "2"));
+
+		// then
+		result.andExpectAll(
+			status().isOk(),
+			jsonPath("$.totalPages").value(2),
+			jsonPath("$.currentPage").value(1),
+			jsonPath("$.totalElements").value(2),
+			jsonPath("$.ranks.length()").value(2),
+			jsonPath("$.ranks[0].nickname").value(nickname));
+	}
+
+	@Test
+	@DataSet("datasets/stat/three-user-stat.yml")
+	@DisplayName("총 유저 수가 3명이고 페이지 크기가 2일 때 3위 유저의 닉네임을 검색하면 두 번째 페이지에 1개의 결과를 반환한다")
+	void totalRankingForThreeUserWithLastRankedNickname() throws Exception {
+		// given
+		String nickname = "USER1";
+
+		// when
+		ResultActions result = mockMvc.perform(
+			get("/stats/rankings/" + nickname).param("size", "2"));
+
+		// then
+		result.andExpectAll(
+			status().isOk(),
+			jsonPath("$.totalPages").value(2),
+			jsonPath("$.currentPage").value(2),
+			jsonPath("$.totalElements").value(1),
+			jsonPath("$.ranks.length()").value(1),
+			jsonPath("$.ranks[0].nickname").value(nickname));
+	}
 }

--- a/backend/src/test/java/io/f1/backend/domain/stat/StatBrowserTest.java
+++ b/backend/src/test/java/io/f1/backend/domain/stat/StatBrowserTest.java
@@ -1,16 +1,14 @@
 package io.f1.backend.domain.stat;
 
 import static io.f1.backend.global.exception.errorcode.CommonErrorCode.INVALID_PAGINATION;
-
 import static io.f1.backend.global.exception.errorcode.RoomErrorCode.PLAYER_NOT_FOUND;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 
-import io.f1.backend.global.exception.errorcode.ErrorCode;
-import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.template.BrowserTestTemplate;
 
 import org.junit.jupiter.api.DisplayName;
@@ -90,60 +88,60 @@ public class StatBrowserTest extends BrowserTestTemplate {
                 jsonPath("$.ranks.length()").value(1));
     }
 
-	@Test
-	@DataSet("datasets/stat/three-user-stat.yml")
-	@DisplayName("랭킹 페이지에서 존재하지 않는 닉네임을 검색하면 예외를 발생시킨다.")
-	void totalRankingWithUnregisteredNickname() throws Exception {
-		// given
-		String nickname = "UNREGISTERED";
+    @Test
+    @DataSet("datasets/stat/three-user-stat.yml")
+    @DisplayName("랭킹 페이지에서 존재하지 않는 닉네임을 검색하면 예외를 발생시킨다.")
+    void totalRankingWithUnregisteredNickname() throws Exception {
+        // given
+        String nickname = "UNREGISTERED";
 
-		// when
-		ResultActions result = mockMvc.perform(get("/stats/rankings/" + nickname));
+        // when
+        ResultActions result = mockMvc.perform(get("/stats/rankings/" + nickname));
 
-		// then
-		result.andExpectAll(
-			status().isNotFound(), jsonPath("$.code").value(PLAYER_NOT_FOUND.getCode()));
-	}
+        // then
+        result.andExpectAll(
+                status().isNotFound(), jsonPath("$.code").value(PLAYER_NOT_FOUND.getCode()));
+    }
 
-	@Test
-	@DataSet("datasets/stat/three-user-stat.yml")
-	@DisplayName("총 유저 수가 3명이고 페이지 크기가 2일 때 1위 유저의 닉네임을 검색하면 첫 번째 페이지에 2개의 결과를 반환한다")
-	void totalRankingForThreeUserWithFirstRankedNickname() throws Exception {
-		// given
-		String nickname = "USER3";
+    @Test
+    @DataSet("datasets/stat/three-user-stat.yml")
+    @DisplayName("총 유저 수가 3명이고 페이지 크기가 2일 때 1위 유저의 닉네임을 검색하면 첫 번째 페이지에 2개의 결과를 반환한다")
+    void totalRankingForThreeUserWithFirstRankedNickname() throws Exception {
+        // given
+        String nickname = "USER3";
 
-		// when
-		ResultActions result = mockMvc.perform(
-			get("/stats/rankings/" + nickname).param("size", "2"));
+        // when
+        ResultActions result =
+                mockMvc.perform(get("/stats/rankings/" + nickname).param("size", "2"));
 
-		// then
-		result.andExpectAll(
-			status().isOk(),
-			jsonPath("$.totalPages").value(2),
-			jsonPath("$.currentPage").value(1),
-			jsonPath("$.totalElements").value(2),
-			jsonPath("$.ranks.length()").value(2),
-			jsonPath("$.ranks[0].nickname").value(nickname));
-	}
+        // then
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.totalPages").value(2),
+                jsonPath("$.currentPage").value(1),
+                jsonPath("$.totalElements").value(2),
+                jsonPath("$.ranks.length()").value(2),
+                jsonPath("$.ranks[0].nickname").value(nickname));
+    }
 
-	@Test
-	@DataSet("datasets/stat/three-user-stat.yml")
-	@DisplayName("총 유저 수가 3명이고 페이지 크기가 2일 때 3위 유저의 닉네임을 검색하면 두 번째 페이지에 1개의 결과를 반환한다")
-	void totalRankingForThreeUserWithLastRankedNickname() throws Exception {
-		// given
-		String nickname = "USER1";
+    @Test
+    @DataSet("datasets/stat/three-user-stat.yml")
+    @DisplayName("총 유저 수가 3명이고 페이지 크기가 2일 때 3위 유저의 닉네임을 검색하면 두 번째 페이지에 1개의 결과를 반환한다")
+    void totalRankingForThreeUserWithLastRankedNickname() throws Exception {
+        // given
+        String nickname = "USER1";
 
-		// when
-		ResultActions result = mockMvc.perform(
-			get("/stats/rankings/" + nickname).param("size", "2"));
+        // when
+        ResultActions result =
+                mockMvc.perform(get("/stats/rankings/" + nickname).param("size", "2"));
 
-		// then
-		result.andExpectAll(
-			status().isOk(),
-			jsonPath("$.totalPages").value(2),
-			jsonPath("$.currentPage").value(2),
-			jsonPath("$.totalElements").value(1),
-			jsonPath("$.ranks.length()").value(1),
-			jsonPath("$.ranks[0].nickname").value(nickname));
-	}
+        // then
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.totalPages").value(2),
+                jsonPath("$.currentPage").value(2),
+                jsonPath("$.totalElements").value(1),
+                jsonPath("$.ranks.length()").value(1),
+                jsonPath("$.ranks[0].nickname").value(nickname));
+    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #89 

## 🪐 작업 내용
- service 계층에 transactional을 빼먹다니
- 닉네임을 통해 랭킹을 조회
  1. nickname을 통해 score를 확인합니다.
  2. score의 페이지 위치를 확인 및 pageable을 생성합니다.
  3. pageable을 통해 페이지를 조회해 결과를 반환합니다.

native query를 사용하면 1-2번 과정의 통합이 가능하지만, 아래와 같은 이유로 native query를 사용하지 않았습니다.
- 테스트 코드에서는 user 테이블이 user_test 테이블로 이름이 변경되기 때문에 native query 사용 시 user 테이블 참조가 불가능합니다.
- MySQL에 종속된 쿼리 사용 시 Redis로의 전환에서 다시 수정이 필요할 수 있습니다.

위 일련의 과정에 대해서는 Redis 리팩토링 시에 효율적인 방법을 찾아보도록 하겠습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?