### PR TITLE
[refactor] exit 응답 추가 

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -174,7 +174,8 @@ public class RoomService {
             /* 방 삭제 */
             if (isLastPlayer(room, sessionId)) {
                 removeRoom(room);
-                messageSender.send(destination, MessageType.EXIT_SUCCESS, new ExitSuccessResponse(true));
+                messageSender.send(
+                        destination, MessageType.EXIT_SUCCESS, new ExitSuccessResponse(true));
                 return;
             }
 
@@ -193,9 +194,9 @@ public class RoomService {
 
             messageSender.send(destination, MessageType.PLAYER_LIST, playerListResponse);
             messageSender.send(destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-            messageSender.send(destination, MessageType.EXIT_SUCCESS, new ExitSuccessResponse(isRemoved));
+            messageSender.send(
+                    destination, MessageType.EXIT_SUCCESS, new ExitSuccessResponse(isRemoved));
         }
-
     }
 
     public void handlePlayerReady(Long roomId, String sessionId) {

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/MessageType.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/MessageType.java
@@ -9,4 +9,5 @@ public enum MessageType {
     CHAT,
     QUESTION_RESULT,
     RANK_UPDATE,
+    EXIT_SUCCESS,
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/ExitSuccessResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/ExitSuccessResponse.java
@@ -1,0 +1,5 @@
+package io.f1.backend.domain.game.dto.response;
+
+public record ExitSuccessResponse(boolean isSuccess) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/ExitSuccessResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/ExitSuccessResponse.java
@@ -1,5 +1,3 @@
 package io.f1.backend.domain.game.dto.response;
 
-public record ExitSuccessResponse(boolean isSuccess) {
-
-}
+public record ExitSuccessResponse(boolean isSuccess) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
@@ -56,12 +56,12 @@ public class Room {
         this.state = newState;
     }
 
-    public void removeUserId(Long id) {
-        this.userIdSessionMap.remove(id);
+    public boolean removeUserId(Long id) {
+        return this.userIdSessionMap.remove(id) != null;
     }
 
-    public void removeSessionId(String sessionId) {
-        this.playerSessionMap.remove(sessionId);
+    public boolean removeSessionId(String sessionId) {
+        return this.playerSessionMap.remove(sessionId) != null;
     }
 
     public void increasePlayerCorrectCount(String sessionId) {


### PR DESCRIPTION
## 🛰️ Issue Number
- #96 

## 🪐 작업 내용
- 현재 `send` 요청과 `disconnect` 요청이 비동기처리로 순서가 보장되지 않아서 exit 로직이 정상 실행되지 않을 가능성이 있음
- 순서를 보장하기 위해 `exit` 요청시 성공 여부를 응답
- 방 삭제 시는 무조건 `true` 반환, 플레이어 삭제시는 `isRemoved` 플래그를 반환 
- 이부분은 프론트엔드 개발자님과 상의가 된 부분이라서 웹소켓 명세서도 추가 완료하였습니다. 
- 응답 확인
<img width="622" height="108" alt="image" src="https://github.com/user-attachments/assets/66966b08-b573-46a4-8cb5-677f701527d3" />



## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?