### PR TITLE
Feat/84

### DIFF
--- a/backend/src/main/java/io/f1/backend/global/config/CustomHandshakeInterceptor.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CustomHandshakeInterceptor.java
@@ -1,7 +1,7 @@
 package io.f1.backend.global.config;
 
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -11,13 +11,19 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import java.util.Map;
+
 @Slf4j
 @Component
 public class CustomHandshakeInterceptor implements HandshakeInterceptor {
 
     @Override
-    public boolean beforeHandshake(ServerHttpRequest request,
-        ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes)
+            throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             response.setStatusCode(HttpStatus.UNAUTHORIZED); // 서버 로그에만 적용되는 StatusCode
@@ -29,10 +35,12 @@ public class CustomHandshakeInterceptor implements HandshakeInterceptor {
     }
 
     @Override
-    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
-        WebSocketHandler wsHandler, Exception exception) {
+    public void afterHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Exception exception) {
         // TODO : 연결 이후, 사용자 웹소켓 세션 로그 및 IP 등 추적 및 메트릭 수집 로직 추가
 
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/global/config/CustomHandshakeInterceptor.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CustomHandshakeInterceptor.java
@@ -1,0 +1,38 @@
+package io.f1.backend.global.config;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+@Slf4j
+@Component
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request,
+        ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            response.setStatusCode(HttpStatus.UNAUTHORIZED); // 서버 로그에만 적용되는 StatusCode
+            return false;
+        }
+
+        attributes.put("auth", authentication);
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+        WebSocketHandler wsHandler, Exception exception) {
+        // TODO : 연결 이후, 사용자 웹소켓 세션 로그 및 IP 등 추적 및 메트릭 수집 로직 추가
+
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/global/config/StompChannelInterceptor.java
+++ b/backend/src/main/java/io/f1/backend/global/config/StompChannelInterceptor.java
@@ -27,16 +27,21 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             throw new IllegalArgumentException("Stomp command required");
         }
 
+        String username = "알수없는 사용자";
+        if (accessor.getUser() != null) {
+            username = accessor.getUser().getName();
+        }
+
         if (command.equals(StompCommand.CONNECT)) {
-            log.info("CONNECT : 세션 연결 - sessionId = {}", sessionId);
+            log.info("user : {} | CONNECT : 세션 연결 - sessionId = {}", username, sessionId);
         } else if (command.equals(StompCommand.SUBSCRIBE)) {
             if (destination != null && sessionId != null) {
-                log.info("SUBSCRIBE : 구독 시작 destination = {}", destination);
+                log.info("user : {} | SUBSCRIBE : 구독 시작 destination = {}", username, destination);
             }
         } else if (command.equals(StompCommand.SEND)) {
-            log.info("SEND : 요청 destination = {}", destination);
+            log.info("user : {} | SEND : 요청 destination = {}", username, destination);
         } else if (command.equals(StompCommand.DISCONNECT)) {
-            log.info("DISCONNECT : 연결 해제 sessionId = {}", sessionId);
+            log.info("user : {} | DISCONNECT : 연결 해제 sessionId = {}", username, sessionId);
         }
 
         return message;

--- a/backend/src/main/java/io/f1/backend/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/WebSocketConfig.java
@@ -8,7 +8,6 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
 @Configuration
 @RequiredArgsConstructor

--- a/backend/src/main/java/io/f1/backend/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/WebSocketConfig.java
@@ -16,11 +16,12 @@ import org.springframework.web.socket.server.support.HttpSessionHandshakeInterce
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompChannelInterceptor stompChannelInterceptor;
+    private final CustomHandshakeInterceptor customHandshakeInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/game-room")
-                .addInterceptors(new HttpSessionHandshakeInterceptor())
+                .addInterceptors(customHandshakeInterceptor)
                 .setAllowedOriginPatterns("*");
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #84 

## 🪐 작업 내용
### 핸드쉐이크 시, 인증객체 넘겨주는 방식을 변경
- 원래 `HttpSessionHandshakeInterceptor`를 사용해 넘겨주도록 했었는데, `CustomHandshakeInterceptor`를 추가하면 **@AfterHandshake**를 오버라이드하여 핸드쉐이크시에, 로그나 메트릭 수집이 용이할 것 같아서 교체를 했습니다.
- 또한, **@BeforeHandshake**를 사용하여 세션저장소가 아닌 http요청스레드에 존재하는 contextHolder의 유저정보를 웹소켓세션 스레드로 넘겨주도록 했습니다.
- 세션저장소를 활용하여 웹소켓세션에 인증정보를 넘겨주는 방식이 표준이지만, 세션저장소에 많은 요청이 몰릴경우, 같은 세션저장소를 사용하기 때문에, 부하가 생길수 있다고 합니다. 반면에, ContextHolder를 사용하면 요청 컨텍스트에서 바로 꺼내서 넘겨줄 수 있으므로 서버 확장시 문제도 없고, 세션저장소의 단점을 보완할 수 있다고 합니다.

### 로그 및 메트릭 수집
- 실제 서비스시 로그 및 메트릭 수집을 위해 @AfterHandshake아래에 TODO를 추가해놓았습니다. 해당 부분에서는 STOMP와 같은 논리적 연결이 아닌 실제 물리적 연결을 추적하고 수집할 수 있습니다.(사용자의 IP, userAgent 등)
- 어떤 메트릭을 수집하면 서비스 운용에 도움이 될지 찾아보겠습니다!

### STOMP 커맨드 로그에, 사용자 정보 추가
- STOMP 커맨드 로그에 사용자 정보를 추가해 조금더 로그가 직관적이도록 변경했습니다.
<img width="1534" height="73" alt="스크린샷 2025-07-20 오후 6 29 12" src="https://github.com/user-attachments/assets/96e6ec11-7870-49ab-ae69-7e2ea40fa28f" />
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?