### PR TITLE
[feat] 유저 닉네임으로 정보 조회

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/admin/api/AdminController.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/api/AdminController.java
@@ -6,10 +6,12 @@ import io.f1.backend.global.validation.LimitPageSize;
 
 import lombok.RequiredArgsConstructor;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,8 +23,14 @@ public class AdminController {
 
     @LimitPageSize
     @GetMapping("/users")
-    public ResponseEntity<UserPageResponse> getUsers(Pageable pageable) {
-        UserPageResponse response = adminService.getAllUsers(pageable);
+    public ResponseEntity<UserPageResponse> getUsers(@RequestParam(required = false) String nickname, Pageable pageable) {
+        UserPageResponse response;
+
+        if(StringUtils.isBlank(nickname)){
+            response = adminService.getAllUsers(pageable);
+        } else {
+            response = adminService.searchUsersByNickname(nickname, pageable);
+        }
         return ResponseEntity.ok().body(response);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/admin/api/AdminController.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/api/AdminController.java
@@ -23,10 +23,11 @@ public class AdminController {
 
     @LimitPageSize
     @GetMapping("/users")
-    public ResponseEntity<UserPageResponse> getUsers(@RequestParam(required = false) String nickname, Pageable pageable) {
+    public ResponseEntity<UserPageResponse> getUsers(
+            @RequestParam(required = false) String nickname, Pageable pageable) {
         UserPageResponse response;
 
-        if(StringUtils.isBlank(nickname)){
+        if (StringUtils.isBlank(nickname)) {
             response = adminService.getAllUsers(pageable);
         } else {
             response = adminService.searchUsersByNickname(nickname, pageable);

--- a/backend/src/main/java/io/f1/backend/domain/admin/app/AdminService.java
+++ b/backend/src/main/java/io/f1/backend/domain/admin/app/AdminService.java
@@ -24,4 +24,10 @@ public class AdminService {
         Page<UserResponse> users = userRepository.findAllUsersWithPaging(pageable);
         return toUserListPageResponse(users);
     }
+
+    @Transactional(readOnly = true)
+    public UserPageResponse searchUsersByNickname(String nickname, Pageable pageable) {
+        Page<UserResponse> users = userRepository.findUsersByNicknameContaining(nickname, pageable);
+        return toUserListPageResponse(users);
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
@@ -66,7 +66,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public void validateNicknameDuplicate(String nickname) {
-        if (userRepository.existsUserByNickname(nickname)) {
+        if (userRepository.existsUserByNicknameIgnoreCase(nickname)) {
             throw new CustomException(UserErrorCode.NICKNAME_CONFLICT);
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -2,14 +2,12 @@ package io.f1.backend.domain.user.dao;
 
 import io.f1.backend.domain.admin.dto.UserResponse;
 import io.f1.backend.domain.user.entity.User;
-
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -19,7 +17,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsUserByNickname(String nickname);
 
     @Query(
-            "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin,"
-                    + " u.createdAt)FROM User u ORDER BY u.id")
+        "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin,"
+            + " u.createdAt)FROM User u ORDER BY u.id")
     Page<UserResponse> findAllUsersWithPaging(Pageable pageable);
+
+    @Query(
+        "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin, u.createdAt) "
+            + "FROM User u "
+            + "WHERE LOWER(u.nickname) LIKE CONCAT('%', LOWER(:nickname), '%')"
+    )
+    Page<UserResponse> findUsersByNicknameContaining(String nickname, Pageable pageable);
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -2,12 +2,14 @@ package io.f1.backend.domain.user.dao;
 
 import io.f1.backend.domain.admin.dto.UserResponse;
 import io.f1.backend.domain.user.entity.User;
-import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -17,14 +19,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsUserByNicknameIgnoreCase(String nickname);
 
     @Query(
-        "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin,"
-            + " u.createdAt)FROM User u ORDER BY u.id")
+            "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin,"
+                    + " u.createdAt)FROM User u ORDER BY u.id")
     Page<UserResponse> findAllUsersWithPaging(Pageable pageable);
 
     @Query(
-        "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin, u.createdAt) "
-            + "FROM User u "
-            + "WHERE LOWER(u.nickname) LIKE CONCAT('%', LOWER(:nickname), '%')"
-    )
+            "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin,"
+                + " u.createdAt) FROM User u WHERE LOWER(u.nickname) LIKE CONCAT('%',"
+                + " LOWER(:nickname), '%')")
     Page<UserResponse> findUsersByNicknameContaining(String nickname, Pageable pageable);
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dao/UserRepository.java
@@ -14,7 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
 
-    Boolean existsUserByNickname(String nickname);
+    Boolean existsUserByNicknameIgnoreCase(String nickname);
 
     @Query(
         "SELECT new io.f1.backend.domain.admin.dto.UserResponse(u.id, u.nickname, u.lastLogin,"

--- a/backend/src/test/java/io/f1/backend/domain/admin/app/AdminServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/admin/app/AdminServiceTests.java
@@ -1,5 +1,6 @@
 package io.f1.backend.domain.admin.app;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,28 +26,46 @@ public class AdminServiceTests extends BrowserTestTemplate {
 
         // then
         result.andExpectAll(
-                status().isOk(),
-                jsonPath("$.totalPages").value(1),
-                jsonPath("$.currentPage").value(1),
-                jsonPath("$.totalElements").value(3),
-                jsonPath("$.users.length()").value(3));
+            status().isOk(),
+            jsonPath("$.totalPages").value(1),
+            jsonPath("$.currentPage").value(1),
+            jsonPath("$.totalElements").value(3),
+            jsonPath("$.users.length()").value(3));
     }
 
     @Test
     @DataSet("datasets/admin/sorted-user.yml")
     @DisplayName("유저 목록이 id 순으로 정렬되어 반환된다")
-    void getUsersSortedByLastLogin() throws Exception {
+    void getUsersSortedByUserId() throws Exception {
         // when
         ResultActions result = mockMvc.perform(get("/admin/users"));
         // then
         result.andExpectAll(
-                status().isOk(),
-                jsonPath("$.totalElements").value(3),
-                // 가장 최근 로그인한 USER3이 첫 번째
-                jsonPath("$.users[0].id").value(1),
-                // 중간 로그인한 USER2가 두 번째
-                jsonPath("$.users[1].id").value(2),
-                // 가장 오래된 로그인한 USER1이 세 번째
-                jsonPath("$.users[2].id").value(3));
+            status().isOk(),
+            jsonPath("$.totalElements").value(3),
+            jsonPath("$.users[0].id").value(1),
+            jsonPath("$.users[1].id").value(2),
+            jsonPath("$.users[2].id").value(3));
+    }
+
+    @Test
+    @DataSet("datasets/admin/search-user.yml")
+    @DisplayName("특정 닉네임이 포함된 유저들의 정보를 조회한다")
+    void searchUsersByNickname() throws Exception {
+        // given
+        String searchNickname = "us";
+        // when
+        ResultActions result = mockMvc.perform(
+            get("/admin/users")
+                .param("nickname", searchNickname)
+        );
+        // then
+        result.andExpectAll(
+            status().isOk(),
+            jsonPath("$.totalElements").value(3),
+            jsonPath("$.users", hasSize(3)),
+            jsonPath("$.users[0].id").value(1),
+            jsonPath("$.users[1].id").value(2),
+            jsonPath("$.users[2].id").value(3));
     }
 }

--- a/backend/src/test/java/io/f1/backend/domain/admin/app/AdminServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/admin/app/AdminServiceTests.java
@@ -26,11 +26,11 @@ public class AdminServiceTests extends BrowserTestTemplate {
 
         // then
         result.andExpectAll(
-            status().isOk(),
-            jsonPath("$.totalPages").value(1),
-            jsonPath("$.currentPage").value(1),
-            jsonPath("$.totalElements").value(3),
-            jsonPath("$.users.length()").value(3));
+                status().isOk(),
+                jsonPath("$.totalPages").value(1),
+                jsonPath("$.currentPage").value(1),
+                jsonPath("$.totalElements").value(3),
+                jsonPath("$.users.length()").value(3));
     }
 
     @Test
@@ -41,11 +41,11 @@ public class AdminServiceTests extends BrowserTestTemplate {
         ResultActions result = mockMvc.perform(get("/admin/users"));
         // then
         result.andExpectAll(
-            status().isOk(),
-            jsonPath("$.totalElements").value(3),
-            jsonPath("$.users[0].id").value(1),
-            jsonPath("$.users[1].id").value(2),
-            jsonPath("$.users[2].id").value(3));
+                status().isOk(),
+                jsonPath("$.totalElements").value(3),
+                jsonPath("$.users[0].id").value(1),
+                jsonPath("$.users[1].id").value(2),
+                jsonPath("$.users[2].id").value(3));
     }
 
     @Test
@@ -55,17 +55,15 @@ public class AdminServiceTests extends BrowserTestTemplate {
         // given
         String searchNickname = "us";
         // when
-        ResultActions result = mockMvc.perform(
-            get("/admin/users")
-                .param("nickname", searchNickname)
-        );
+        ResultActions result =
+                mockMvc.perform(get("/admin/users").param("nickname", searchNickname));
         // then
         result.andExpectAll(
-            status().isOk(),
-            jsonPath("$.totalElements").value(3),
-            jsonPath("$.users", hasSize(3)),
-            jsonPath("$.users[0].id").value(1),
-            jsonPath("$.users[1].id").value(2),
-            jsonPath("$.users[2].id").value(3));
+                status().isOk(),
+                jsonPath("$.totalElements").value(3),
+                jsonPath("$.users", hasSize(3)),
+                jsonPath("$.users[0].id").value(1),
+                jsonPath("$.users[1].id").value(2),
+                jsonPath("$.users[2].id").value(3));
     }
 }

--- a/backend/src/test/resources/datasets/admin/search-user.yml
+++ b/backend/src/test/resources/datasets/admin/search-user.yml
@@ -1,0 +1,22 @@
+
+user_test:
+  - id: 1
+    nickname: "US"
+    provider: "kakao"
+    provider_id: "kakao1"
+    last_login: 2025-07-16 09:00:00
+    created_at: 2025-07-01 10:00:00
+
+  - id: 2
+    nickname: "USE"
+    provider: "kakao"
+    provider_id: "kakao2"
+    last_login: 2025-07-17 12:00:00
+    created_at: 2025-07-02 10:00:00
+
+  - id: 3
+    nickname: "USER"
+    provider: "kakao"
+    provider_id: "kakao3"
+    last_login: 2025-07-18 15:00:00
+    created_at: 2025-07-03 10:00:00


### PR DESCRIPTION
## 🛰️ Issue Number
- #99 

## 🪐 작업 내용
- 관리자 유저 목록 조회 화면에서 유저 정보 검색 시 사용될 기능을 구현했습니다
- /admin/users 에 해당하는 API 명세서를 수정했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?