### PR TITLE
[feat] 게임 종료 구현

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -24,6 +24,7 @@ import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.GameErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -24,12 +24,12 @@ import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.GameErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
-import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -85,28 +85,33 @@ public class GameService {
 
         Map<String, Player> playerSessionMap = room.getPlayerSessionMap();
 
-        messageSender.send(destination, MessageType.GAME_RESULT, toGameResultListResponse(playerSessionMap, room.getGameSetting().getRound()));
+        messageSender.send(
+                destination,
+                MessageType.GAME_RESULT,
+                toGameResultListResponse(playerSessionMap, room.getGameSetting().getRound()));
 
         List<Player> disconnectedPlayers = new ArrayList<>();
 
         room.initializeRound();
         for (Player player : playerSessionMap.values()) {
-            if(player.getState().equals(ConnectionState.DISCONNECTED)) {
+            if (player.getState().equals(ConnectionState.DISCONNECTED)) {
                 disconnectedPlayers.add(player);
             }
             player.initializeCorrectCount();
             player.toggleReady();
         }
 
-        for(Player player : disconnectedPlayers) {
+        for (Player player : disconnectedPlayers) {
             String sessionId = room.getUserIdSessionMap().get(player.id);
             roomService.exitRoomForDisconnectedPlayer(roomId, player, sessionId);
         }
 
         room.updateRoomState(RoomState.WAITING);
         messageSender.send(destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
-        messageSender.send(destination, MessageType.GAME_SETTING, toGameSettingResponse(room.getGameSetting(), room.getCurrentQuestion()
-            .getQuiz()));
+        messageSender.send(
+                destination,
+                MessageType.GAME_SETTING,
+                toGameSettingResponse(room.getGameSetting(), room.getCurrentQuestion().getQuiz()));
         messageSender.send(destination, MessageType.ROOM_SETTING, toRoomSettingResponse(room));
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -4,6 +4,7 @@ import static io.f1.backend.domain.game.mapper.RoomMapper.toGameResultListRespon
 import static io.f1.backend.domain.game.mapper.RoomMapper.toGameSettingResponse;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toPlayerListResponse;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toQuestionStartResponse;
+import static io.f1.backend.domain.game.mapper.RoomMapper.toRankUpdateResponse;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSettingResponse;
 import static io.f1.backend.domain.game.websocket.WebSocketUtils.getDestination;
 import static io.f1.backend.domain.quiz.mapper.QuizMapper.toGameStartResponse;
@@ -71,6 +72,7 @@ public class GameService {
         timerService.startTimer(room, START_DELAY);
 
         messageSender.send(destination, MessageType.GAME_START, toGameStartResponse(questions));
+        messageSender.send(destination, MessageType.RANK_UPDATE, toRankUpdateResponse(room));
         messageSender.send(
                 destination,
                 MessageType.QUESTION_START,

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -4,13 +4,11 @@ import static io.f1.backend.domain.game.mapper.RoomMapper.toGameResultListRespon
 import static io.f1.backend.domain.game.mapper.RoomMapper.toGameSettingResponse;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toPlayerListResponse;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toQuestionStartResponse;
-import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSetting;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSettingResponse;
 import static io.f1.backend.domain.game.websocket.WebSocketUtils.getDestination;
 import static io.f1.backend.domain.quiz.mapper.QuizMapper.toGameStartResponse;
 
 import io.f1.backend.domain.game.dto.MessageType;
-import io.f1.backend.domain.game.dto.response.GameResultResponse;
 import io.f1.backend.domain.game.event.RoomUpdatedEvent;
 import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
@@ -25,7 +23,6 @@ import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.GameErrorCode;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 
-import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -85,11 +82,16 @@ public class GameService {
 
         Map<String, Player> playerSessionMap = room.getPlayerSessionMap();
 
-        messageSender.send(destination, MessageType.GAME_SETTING, toGameSettingResponse(room.getGameSetting(), room.getCurrentQuestion()
-            .getQuiz()));
+        messageSender.send(
+                destination,
+                MessageType.GAME_SETTING,
+                toGameSettingResponse(room.getGameSetting(), room.getCurrentQuestion().getQuiz()));
         messageSender.send(destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         messageSender.send(destination, MessageType.ROOM_SETTING, toRoomSettingResponse(room));
-        messageSender.send(destination, MessageType.GAME_RESULT, toGameResultListResponse(playerSessionMap, room.getGameSetting().getRound()));
+        messageSender.send(
+                destination,
+                MessageType.GAME_RESULT,
+                toGameResultListResponse(playerSessionMap, room.getGameSetting().getRound()));
 
         room.initializeRound();
         for (Player player : playerSessionMap.values()) {

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -336,4 +336,31 @@ public class RoomService {
         room.removeUserId(removePlayer.getId());
         room.removeSessionId(sessionId);
     }
+
+    public void exitRoomForDisconnectedPlayer(Long roomId, Player player, String sessionId) {
+
+        // 연결 끊긴 플레이어 exit 로직 타게 해주기
+        Room room = findRoom(roomId);
+
+        /* 방 삭제 */
+        if (isLastPlayer(room, sessionId)) {
+            removeRoom(room);
+            return;
+        }
+
+        /* 방장 변경 */
+        if (room.isHost(player.getId())) {
+            changeHost(room, sessionId);
+        }
+
+        /* 플레이어 삭제 */
+        removePlayer(room, sessionId, player);
+
+        SystemNoticeResponse systemNoticeResponse =
+            ofPlayerEvent(player.nickname, RoomEventType.EXIT);
+
+        String destination = getDestination(roomId);
+
+        messageSender.send(destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @RequiredArgsConstructor
 public class RoomService {
 
+    private final GameService gameService;
     private final TimerService timerService;
     private final QuizService quizService;
     private final RoomRepository roomRepository;
@@ -263,9 +264,8 @@ public class RoomService {
 
             timerService.cancelTimer(room);
 
-            // TODO : 게임 종료 로직 추가
             if (!timerService.validateCurrentRound(room)) {
-                // 게임 종료 로직
+                gameService.gameEnd(room);
                 return;
             }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -357,7 +357,7 @@ public class RoomService {
         removePlayer(room, sessionId, player);
 
         SystemNoticeResponse systemNoticeResponse =
-            ofPlayerEvent(player.nickname, RoomEventType.EXIT);
+                ofPlayerEvent(player.nickname, RoomEventType.EXIT);
 
         String destination = getDestination(roomId);
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/TimerService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/TimerService.java
@@ -26,6 +26,8 @@ public class TimerService {
     private static final String NONE_CORRECT_USER = "";
     private static final int CONTINUE_DELAY = 3;
 
+    private final GameService gameService;
+
     public void startTimer(Room room, int delaySec) {
         cancelTimer(room);
 
@@ -53,14 +55,11 @@ public class TimerService {
                 MessageType.SYSTEM_NOTICE,
                 ofPlayerEvent(NONE_CORRECT_USER, RoomEventType.TIMEOUT));
 
-        // TODO : 게임 종료 로직
         if (!validateCurrentRound(room)) {
-            // 게임 종료 로직
-            // GAME_SETTING, PLAYER_LIST, GAME_RESULT, ROOM_SETTING
+            gameService.gameEnd(room);
             return;
         }
 
-        // 다음 문제 출제
         room.increaseCurrentRound();
 
         startTimer(room, CONTINUE_DELAY);

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/MessageType.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/MessageType.java
@@ -9,5 +9,6 @@ public enum MessageType {
     CHAT,
     QUESTION_RESULT,
     RANK_UPDATE,
-    QUESTION_START
+    QUESTION_START,
+    GAME_RESULT
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultListResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultListResponse.java
@@ -1,0 +1,7 @@
+package io.f1.backend.domain.game.dto.response;
+
+import java.util.List;
+
+public record GameResultListResponse(List<GameResultResponse> result) {
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultListResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultListResponse.java
@@ -2,6 +2,4 @@ package io.f1.backend.domain.game.dto.response;
 
 import java.util.List;
 
-public record GameResultListResponse(List<GameResultResponse> result) {
-
-}
+public record GameResultListResponse(List<GameResultResponse> result) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultResponse.java
@@ -1,0 +1,4 @@
+package io.f1.backend.domain.game.dto.response;
+
+public record GameResultResponse(String nickname, int score, int totalCorrectCount, int rank) {
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/GameResultResponse.java
@@ -1,4 +1,3 @@
 package io.f1.backend.domain.game.dto.response;
 
-public record GameResultResponse(String nickname, int score, int totalCorrectCount, int rank) {
-}
+public record GameResultResponse(String nickname, int score, int totalCorrectCount, int rank) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
@@ -114,18 +114,21 @@ public class RoomMapper {
                 Instant.now().plusSeconds(delay));
     }
 
-    public static GameResultResponse toGameResultResponse(Player player, int round, int rank, int totalPlayers) {
+    public static GameResultResponse toGameResultResponse(
+            Player player, int round, int rank, int totalPlayers) {
         double correctRate = (double) player.getCorrectCount() / round;
         int score = (int) (correctRate * 100) + (totalPlayers - rank) * 5;
 
         return new GameResultResponse(player.nickname, score, player.getCorrectCount(), rank);
     }
 
-    public static GameResultListResponse toGameResultListResponse(Map<String, Player> playerSessionMap, int round) {
+    public static GameResultListResponse toGameResultListResponse(
+            Map<String, Player> playerSessionMap, int round) {
 
-        List<Player> rankedPlayers = playerSessionMap.values().stream()
-            .sorted(Comparator.comparingInt(Player::getCorrectCount).reversed())
-            .toList();
+        List<Player> rankedPlayers =
+                playerSessionMap.values().stream()
+                        .sorted(Comparator.comparingInt(Player::getCorrectCount).reversed())
+                        .toList();
 
         int totalPlayers = rankedPlayers.size();
 
@@ -133,12 +136,12 @@ public class RoomMapper {
         int rank = 0;
 
         List<GameResultResponse> gameResults = new ArrayList<>();
-        for(int i=0; i<totalPlayers; i++) {
+        for (int i = 0; i < totalPlayers; i++) {
             Player player = rankedPlayers.get(i);
 
             int correctCnt = player.getCorrectCount();
 
-            if(prevCorrectCnt != correctCnt) {
+            if (prevCorrectCnt != correctCnt) {
                 rank = i + 1;
             }
 
@@ -149,4 +152,3 @@ public class RoomMapper {
         return new GameResultListResponse(gameResults);
     }
 }
-

--- a/backend/src/main/java/io/f1/backend/domain/game/model/Player.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/model/Player.java
@@ -27,4 +27,8 @@ public class Player {
     public void increaseCorrectCount() {
         correctCount++;
     }
+
+    public void initializeCorrectCount() {
+        correctCount = 0;
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
@@ -90,4 +90,8 @@ public class Room {
     public void increaseCurrentRound() {
         currentRound++;
     }
+
+    public void initializeRound() {
+        currentRound = 0;
+    }
 }

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -55,7 +55,12 @@ class RoomServiceTests {
         MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
         roomService =
                 new RoomService(
-                        gameService ,timerService, quizService, roomRepository, eventPublisher, messageSender);
+                        gameService,
+                        timerService,
+                        quizService,
+                        roomRepository,
+                        eventPublisher,
+                        messageSender);
 
         SecurityContextHolder.clearContext();
     }

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -45,6 +45,7 @@ class RoomServiceTests {
 
     @Mock private RoomRepository roomRepository;
     @Mock private QuizService quizService;
+    @Mock private GameService gameService;
     @Mock private TimerService timerService;
     @Mock private ApplicationEventPublisher eventPublisher;
     @Mock private MessageSender messageSender;
@@ -54,7 +55,7 @@ class RoomServiceTests {
         MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
         roomService =
                 new RoomService(
-                        timerService, quizService, roomRepository, eventPublisher, messageSender);
+                        gameService ,timerService, quizService, roomRepository, eventPublisher, messageSender);
 
         SecurityContextHolder.clearContext();
     }


### PR DESCRIPTION
## 🛰️ Issue Number
- #103 

## 🪐 작업 내용
### 게임 종료 구현

- 게임 종료 시 초기화 해야 하는 것들
    - 방 현재 라운드 초기화 : 0
    - 방 state : finished → waiting 으로 순차 변경 (혹시 몰라 finished 상태도 사용하긴 했는데, 룸 상태에 대한 의견 주시면 좋을 것 같습니다!)
    - 방 타이머 shutdown() 리소스 정리 (validateCurrentRound() 해줄 때 함)
    - 플레이어 맞힌 개수 초기화 : 0
    - 플레이어 레디 상태 풀어주기
    - 플레이어 DISCONNECTED 상태 → exitRoomForDisconnectedPlayer 로직

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?