### PR TITLE
[feat] 마이페이지 조회 기능

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
@@ -6,11 +6,9 @@ import io.f1.backend.domain.stat.dto.StatPageResponse;
 import io.f1.backend.domain.stat.dto.StatResponse;
 import io.f1.backend.domain.stat.dto.StatWithNicknameAndUserId;
 import io.f1.backend.domain.user.dto.MyPage;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -21,6 +19,11 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Repository
 @RequiredArgsConstructor
@@ -161,11 +164,10 @@ public class StatRedisRepository {
         }
 
         return new MyPage(
-            (String) statMap.get("nickname"),
-            rank + 1,
-            (long) statMap.get("totalGames"),
-            (long) statMap.get("winningGames"),
-            score.longValue()
-        );
+                (String) statMap.get("nickname"),
+                rank + 1,
+                (long) statMap.get("totalGames"),
+                (long) statMap.get("winningGames"),
+                score.longValue());
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
@@ -1,8 +1,8 @@
 package io.f1.backend.domain.stat.dao;
 
 import io.f1.backend.domain.stat.dto.StatPageResponse;
-
 import io.f1.backend.domain.user.dto.MyPage;
+
 import org.springframework.data.domain.Pageable;
 
 public interface StatRepository {

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepository.java
@@ -2,6 +2,7 @@ package io.f1.backend.domain.stat.dao;
 
 import io.f1.backend.domain.stat.dto.StatPageResponse;
 
+import io.f1.backend.domain.user.dto.MyPage;
 import org.springframework.data.domain.Pageable;
 
 public interface StatRepository {
@@ -17,4 +18,6 @@ public interface StatRepository {
     void updateNickname(long userId, String nickname);
 
     void removeUser(long userId);
+
+    MyPage getMyPageByUserId(long userId);
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepositoryAdapter.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepositoryAdapter.java
@@ -9,9 +9,12 @@ import io.f1.backend.domain.user.dto.MyPage;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
+
 import jakarta.annotation.PostConstruct;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -109,19 +112,13 @@ public class StatRepositoryAdapter implements StatRepository {
         long rank = jpaRepository.countByScoreGreaterThan(stat.score()) + 1;
 
         return new MyPage(
-            stat.nickname(),
-            rank,
-            stat.totalGames(),
-            stat.winningGames(),
-            stat.score()
-        );
+                stat.nickname(), rank, stat.totalGames(), stat.winningGames(), stat.score());
     }
 
     private StatWithNicknameAndUserId findFirstMatchingStat(long userId) {
-        return jpaRepository.findAllStatWithNicknameAndUserId()
-            .stream()
-            .filter(stat -> stat.userId() == userId)
-            .findFirst()
-            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        return jpaRepository.findAllStatWithNicknameAndUserId().stream()
+                .filter(stat -> stat.userId() == userId)
+                .findFirst()
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/api/UserController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/UserController.java
@@ -3,6 +3,7 @@ package io.f1.backend.domain.user.api;
 import static io.f1.backend.global.util.SecurityUtils.logout;
 
 import io.f1.backend.domain.user.app.UserService;
+import io.f1.backend.domain.user.dto.MyPage;
 import io.f1.backend.domain.user.dto.SignupRequest;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,5 +43,11 @@ public class UserController {
         userService.updateNickname(
                 userPrincipal.getUserId(), signupRequest.nickname(), httpSession);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<MyPage> getMyPage(@AuthenticationPrincipal UserPrincipal userPrincipal){
+        MyPage response = userService.getMyPage(userPrincipal);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/api/UserController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/UserController.java
@@ -46,7 +46,7 @@ public class UserController {
     }
 
     @GetMapping
-    public ResponseEntity<MyPage> getMyPage(@AuthenticationPrincipal UserPrincipal userPrincipal){
+    public ResponseEntity<MyPage> getMyPage(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         MyPage response = userService.getMyPage(userPrincipal);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
@@ -20,8 +20,11 @@ import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 import io.f1.backend.global.util.RedisPublisher;
 import io.f1.backend.global.util.SecurityUtils;
+
 import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/UserService.java
@@ -7,8 +7,10 @@ import static io.f1.backend.global.util.RedisPublisher.USER_NEW;
 import static io.f1.backend.global.util.RedisPublisher.USER_UPDATE;
 
 import io.f1.backend.domain.auth.dto.CurrentUserAndAdminResponse;
+import io.f1.backend.domain.stat.dao.StatRepository;
 import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.dto.AuthenticationUser;
+import io.f1.backend.domain.user.dto.MyPage;
 import io.f1.backend.domain.user.dto.SignupRequest;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.dto.UserSummary;
@@ -18,11 +20,8 @@ import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 import io.f1.backend.global.util.RedisPublisher;
 import io.f1.backend.global.util.SecurityUtils;
-
 import jakarta.servlet.http.HttpSession;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +31,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final RedisPublisher redisPublisher;
+    private final StatRepository statRepository;
 
     @Transactional
     public CurrentUserAndAdminResponse signup(HttpSession session, SignupRequest signupRequest) {
@@ -121,5 +121,11 @@ public class UserService {
     public void checkNickname(String nickname) {
         validateNicknameFormat(nickname);
         validateNicknameDuplicate(nickname);
+    }
+
+    @Transactional(readOnly = true)
+    public MyPage getMyPage(UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUserId();
+        return statRepository.getMyPageByUserId(userId);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/MyPage.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/MyPage.java
@@ -1,9 +1,3 @@
 package io.f1.backend.domain.user.dto;
 
-public record MyPage(
-    String nickname,
-    long rank,
-    long score,
-    long totalGames,
-    long winningGames
-) {}
+public record MyPage(String nickname, long rank, long score, long totalGames, long winningGames) {}

--- a/backend/src/main/java/io/f1/backend/domain/user/dto/MyPage.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/dto/MyPage.java
@@ -1,0 +1,9 @@
+package io.f1.backend.domain.user.dto;
+
+public record MyPage(
+    String nickname,
+    long rank,
+    long score,
+    long totalGames,
+    long winningGames
+) {}


### PR DESCRIPTION
## 🛰️ Issue Number
- #106 

## 🪐 작업 내용
- 마이페이지 조회 기능을 구현했습니다.
- Redis를 먼저 조회하고, Redis에 데이터가 없을 경우 MySQL을 조회하는 방식으로 구현했습니다.
```java
@Override
    public MyPage getMyPageByUserId(long userId) {
        try {
            return redisRepository.getStatByUserId(userId);
        } catch (Exception e) {
            log.error("Redis miss, fallback to MySQL for userId={}", userId, e);
        }

        StatWithNicknameAndUserId stat = findFirstMatchingStat(userId);
        long rank = jpaRepository.countByScoreGreaterThan(stat.score()) + 1;

        return new MyPage(
            stat.nickname(),
            rank,
            stat.totalGames(),
            stat.winningGames(),
            stat.score()
        );
    }
```

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?