### PR TITLE
[test] 테스트 코드 수정 (User.SetId() 제거)

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -35,8 +35,4 @@ public class RoomRepositoryImpl implements RoomRepository {
         roomMap.remove(roomId);
     }
 
-    // 테스트 전용 메소드
-    public Room getRoomForTest(Long roomId) {
-        return roomMap.get(roomId);
-    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/store/RoomRepositoryImpl.java
@@ -34,5 +34,4 @@ public class RoomRepositoryImpl implements RoomRepository {
     public void removeRoom(Long roomId) {
         roomMap.remove(roomId);
     }
-
 }

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -16,7 +16,6 @@ import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.util.SecurityUtils;
 
-import java.lang.reflect.Field;
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,24 +45,19 @@ class RoomServiceTests {
 
     private RoomService roomService;
 
-    @Mock
-    private RoomRepository roomRepository;
-    @Mock
-    private QuizService quizService;
-    @Mock
-    private TimerService timerService;
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
-    @Mock
-    private MessageSender messageSender;
+    @Mock private RoomRepository roomRepository;
+    @Mock private QuizService quizService;
+    @Mock private TimerService timerService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private MessageSender messageSender;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
 
         roomService =
-            new RoomService(
-                timerService, quizService, roomRepository, eventPublisher, messageSender);
+                new RoomService(
+                        timerService, quizService, roomRepository, eventPublisher, messageSender);
 
         SecurityContextHolder.clearContext();
     }
@@ -95,17 +90,17 @@ class RoomServiceTests {
             User user = createUser(i);
 
             executorService.submit(
-                () -> {
-                    try {
-                        SecurityUtils.setAuthentication(user);
-                        roomService.enterRoom(roomValidationRequest);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    } finally {
-                        SecurityContextHolder.clearContext();
-                        countDownLatch.countDown();
-                    }
-                });
+                    () -> {
+                        try {
+                            SecurityUtils.setAuthentication(user);
+                            roomService.enterRoom(roomValidationRequest);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            countDownLatch.countDown();
+                        }
+                    });
         }
         countDownLatch.await();
         assertThat(room.getCurrentUserCnt()).isEqualTo(room.getRoomSetting().maxUserCount());
@@ -156,32 +151,32 @@ class RoomServiceTests {
             String sessionId = "sessionId" + i;
             User user = createUser(i);
             executorService.submit(
-                () -> {
-                    try {
-                        UserPrincipal principal =
-                            new UserPrincipal(user, Collections.emptyMap());
-                        SecurityUtils.setAuthentication(user);
-                        log.info("room.getHost().getId() = {}", room.getHost().getId());
-                        roomService.exitRoom(roomId, sessionId, principal);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    } finally {
-                        SecurityContextHolder.clearContext();
-                        countDownLatch.countDown();
-                    }
-                });
+                    () -> {
+                        try {
+                            UserPrincipal principal =
+                                    new UserPrincipal(user, Collections.emptyMap());
+                            SecurityUtils.setAuthentication(user);
+                            log.info("room.getHost().getId() = {}", room.getHost().getId());
+                            roomService.exitRoom(roomId, sessionId, principal);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            countDownLatch.countDown();
+                        }
+                    });
         }
         countDownLatch.await();
         verify(roomRepository).removeRoom(roomId);
     }
 
     private Room createRoom(
-        Long roomId,
-        Long playerId,
-        Long quizId,
-        String password,
-        int maxUserCount,
-        boolean locked) {
+            Long roomId,
+            Long playerId,
+            Long quizId,
+            String password,
+            int maxUserCount,
+            boolean locked) {
         RoomSetting roomSetting = new RoomSetting("방제목", maxUserCount, locked, password);
         GameSetting gameSetting = new GameSetting(quizId, 10, 60);
         Player host = new Player(playerId, "nickname");
@@ -196,11 +191,11 @@ class RoomServiceTests {
         LocalDateTime lastLogin = LocalDateTime.now();
 
         User user =
-            User.builder()
-                .provider(provider)
-                .providerId(providerId)
-                .lastLogin(lastLogin)
-                .build();
+                User.builder()
+                        .provider(provider)
+                        .providerId(providerId)
+                        .lastLogin(lastLogin)
+                        .build();
 
         try {
             Field idField = User.class.getDeclaredField("id");

--- a/backend/src/test/java/io/f1/backend/domain/game/store/RoomRepositoryTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/store/RoomRepositoryTests.java
@@ -52,7 +52,7 @@ class RoomRepositoryTests {
 
         roomRepository.saveRoom(newRoom);
 
-        Room savedRoom = roomRepository.getRoomForTest(newId);
+        Room savedRoom = roomRepository.findRoom(newId).orElseThrow();
 
         assertThat(savedRoom.getHost().getId()).isEqualTo(loginUser.get("id"));
         assertThat(savedRoom.getHost().getNickname()).isEqualTo(loginUser.get("nickname"));

--- a/backend/src/test/java/io/f1/backend/domain/game/websocket/SessionServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/websocket/SessionServiceTests.java
@@ -17,12 +17,7 @@ import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.websocket.service.SessionService;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
-import java.lang.reflect.Field;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +26,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTests {
@@ -236,11 +238,11 @@ class SessionServiceTests {
         LocalDateTime lastLogin = LocalDateTime.now();
 
         User user =
-            User.builder()
-                .provider(provider)
-                .providerId(providerId)
-                .lastLogin(lastLogin)
-                .build();
+                User.builder()
+                        .provider(provider)
+                        .providerId(providerId)
+                        .lastLogin(lastLogin)
+                        .build();
 
         try {
             Field idField = User.class.getDeclaredField("id");

--- a/backend/src/test/java/io/f1/backend/domain/game/websocket/SessionServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/websocket/SessionServiceTests.java
@@ -1,6 +1,9 @@
 package io.f1.backend.domain.game.websocket;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -14,7 +17,12 @@ import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.websocket.service.SessionService;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
-
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,12 +31,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTests {
@@ -41,9 +43,7 @@ class SessionServiceTests {
     private String sessionId1 = "session1";
     private String sessionId2 = "session2";
     private Long userId1 = 100L;
-    private Long userId2 = 200L;
     private Long roomId1 = 1L;
-    private Long roomId2 = 2L;
 
     @BeforeEach
     void setUp() {
@@ -95,8 +95,7 @@ class SessionServiceTests {
         sessionService.addRoomId(roomId1, sessionId1);
         sessionService.addSession(sessionId1, userId1);
 
-        User user = new User("provider", "providerId", LocalDateTime.now());
-        user.setId(userId1);
+        User user = createUser(1);
         UserPrincipal principal = new UserPrincipal(user, new HashMap<>());
 
         // disconnect 호출
@@ -154,8 +153,7 @@ class SessionServiceTests {
         sessionService.addSession(sessionId1, userId1); // 유저의 현재 활성 세션
         sessionService.addRoomId(roomId1, sessionId1);
 
-        User user = new User("provider", "providerId", LocalDateTime.now());
-        user.setId(userId1);
+        User user = createUser(1);
         UserPrincipal principal = new UserPrincipal(user, new HashMap<>());
 
         // when
@@ -183,8 +181,7 @@ class SessionServiceTests {
         sessionService.addSession(sessionId1, userId1); // 초기 세션
         sessionService.addRoomId(roomId1, sessionId1);
 
-        User user = new User("provider", "providerId", LocalDateTime.now());
-        user.setId(userId1);
+        User user = createUser(1);
         UserPrincipal principal = new UserPrincipal(user, new HashMap<>());
 
         sessionService.handleUserDisconnect(
@@ -230,5 +227,29 @@ class SessionServiceTests {
         assertEquals(userId1, sessionIdUser.get(sessionId2));
         assertTrue(sessionIdRoom.containsKey(sessionId2));
         assertEquals(roomId1, sessionIdRoom.get(sessionId2));
+    }
+
+    private User createUser(int i) {
+        Long userId = i + 1L;
+        String provider = "provider +" + i;
+        String providerId = "providerId" + i;
+        LocalDateTime lastLogin = LocalDateTime.now();
+
+        User user =
+            User.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .lastLogin(lastLogin)
+                .build();
+
+        try {
+            Field idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(user, userId);
+        } catch (Exception e) {
+            throw new RuntimeException("ID 설정 실패", e);
+        }
+
+        return user;
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #117

## 🪐 작업 내용

- dbRider를 적용해보려고했으나, 스레드 동시성 테스트 같은 경우 스레드갯수에 따라서 동적으로 user를 생성하고있기에 적용하지 못함 
- User.setId()를 제거하기위해 리플렉션 사용 
- sessionService 테스트에서는 @ExtendWith(MockitoExtension.class) 로 단위테스트를 하고있기 때문에 dbRider를 적용하지 않았고 
- 위와 같이 리플렉션으로 setId를 대체하였습니다!

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?