### PR TITLE
[fix] 게임 종료 시 PLAYER_LIST 메세지 누락, 방장 레디 풀림 이슈 해결

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -176,12 +176,13 @@ public class GameService {
         room.initializePlayers();
 
         List<Player> disconnectedPlayers = room.getDisconnectedPlayers();
+
         if (!disconnectedPlayers.isEmpty()) {
             roomService.handleDisconnectedPlayers(room, disconnectedPlayers);
-        } else {
-            messageSender.sendBroadcast(
-                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         }
+
+        messageSender.sendBroadcast(
+                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
 
         room.updateRoomState(RoomState.WAITING);
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -179,10 +179,11 @@ public class GameService {
 
         if (!disconnectedPlayers.isEmpty()) {
             roomService.handleDisconnectedPlayers(room, disconnectedPlayers);
+        } else {
+            messageSender.sendBroadcast(
+                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         }
 
-        messageSender.sendBroadcast(
-                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
 
         room.updateRoomState(RoomState.WAITING);
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -181,9 +181,8 @@ public class GameService {
             roomService.handleDisconnectedPlayers(room, disconnectedPlayers);
         } else {
             messageSender.sendBroadcast(
-                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         }
-
 
         room.updateRoomState(RoomState.WAITING);
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -176,11 +176,11 @@ public class GameService {
         room.initializePlayers();
 
         List<Player> disconnectedPlayers = room.getDisconnectedPlayers();
-        if(!disconnectedPlayers.isEmpty()) {
+        if (!disconnectedPlayers.isEmpty()) {
             roomService.handleDisconnectedPlayers(room, disconnectedPlayers);
         } else {
             messageSender.sendBroadcast(
-                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         }
 
         room.updateRoomState(RoomState.WAITING);

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -176,7 +176,12 @@ public class GameService {
         room.initializePlayers();
 
         List<Player> disconnectedPlayers = room.getDisconnectedPlayers();
-        roomService.handleDisconnectedPlayers(room, disconnectedPlayers);
+        if(!disconnectedPlayers.isEmpty()) {
+            roomService.handleDisconnectedPlayers(room, disconnectedPlayers);
+        } else {
+            messageSender.sendBroadcast(
+                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+        }
 
         room.updateRoomState(RoomState.WAITING);
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -339,8 +339,6 @@ public class RoomService {
                     ofPlayerEvent(player.nickname, RoomEventType.EXIT);
 
             messageSender.sendBroadcast(
-                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
-            messageSender.sendBroadcast(
                     destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
         }
     }
@@ -366,5 +364,10 @@ public class RoomService {
             String sessionId = room.getSessionIdByUserId(player.getId());
             exitRoomForDisconnectedPlayer(room.getId(), player, sessionId);
         }
+
+        String destination = getDestination(room.getId());
+
+        messageSender.sendBroadcast(
+            destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -341,7 +341,7 @@ public class RoomService {
             messageSender.sendBroadcast(
                     destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
             messageSender.sendBroadcast(
-                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         }
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -340,6 +340,8 @@ public class RoomService {
 
             messageSender.sendBroadcast(
                     destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
+            messageSender.sendBroadcast(
+                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
         }
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -368,6 +368,6 @@ public class RoomService {
         String destination = getDestination(room.getId());
 
         messageSender.sendBroadcast(
-            destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -364,10 +364,5 @@ public class RoomService {
             String sessionId = room.getSessionIdByUserId(player.getId());
             exitRoomForDisconnectedPlayer(room.getId(), player, sessionId);
         }
-
-        String destination = getDestination(room.getId());
-
-        messageSender.sendBroadcast(
-                destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/model/Room.java
@@ -138,8 +138,8 @@ public class Room {
                 .forEach(
                         player -> {
                             player.initializeCorrectCount();
-                            player.toggleReady();
                         });
+        resetAllPlayerReadyStates();
     }
 
     public String getSessionIdByUserId(Long userId) {

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -47,8 +47,6 @@ class RoomServiceTests {
 
     @Mock private RoomRepository roomRepository;
     @Mock private QuizService quizService;
-    @Mock private GameService gameService;
-    @Mock private TimerService timerService;
     @Mock private ApplicationEventPublisher eventPublisher;
     @Mock private MessageSender messageSender;
 
@@ -58,7 +56,7 @@ class RoomServiceTests {
 
         roomService =
                 new RoomService(
-                        timerService, quizService, roomRepository, eventPublisher, messageSender);
+                        quizService, roomRepository, eventPublisher, messageSender);
 
         SecurityContextHolder.clearContext();
     }

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -54,9 +54,7 @@ class RoomServiceTests {
     void setUp() {
         MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
 
-        roomService =
-                new RoomService(
-                        quizService, roomRepository, eventPublisher, messageSender);
+        roomService = new RoomService(quizService, roomRepository, eventPublisher, messageSender);
 
         SecurityContextHolder.clearContext();
     }


### PR DESCRIPTION
## 🛰️ Issue Number
- #124 

## 🪐 작업 내용
### 1. 방장 레디 풀림 이슈
- 제가 모든 플레이어의 레디 상태를 원상복구 시켜놔서 발생했던 이슈입니다. 
-  `resetAllPlayerReadyStates();` 메서드를 이용해서 방장을 제외한 플레이어의 레디 상태만 바꾸도록 변경했습니다.

### 2. PLAYER_LIST 메세지 누락 이슈
- 연결이 끊긴 플레이어가 있을 때만 PLAYER_LIST가 브로드캐스팅되도록 되어있었습니다.
- disconnectedPlayers 리스트가 비었을 때만 해당 로직을 타고, 아닐 때는 PLAYER_LIST를 바로 브로드캐스팅해주도록 분기 처리했습니다.

### 3. `PLAYER_LIST` 브로드캐스팅 여러번 되는 이슈
- 연결이 끊긴 플레이어가 있을 때, SYSTEM_NOTICE, PLAYER_LIST를 여러 번 브로드캐스팅하게끔 구현되어있었습니다.
- SYSTEM_NOTICE는 개별 플레이어가 나갈 때마다 브로드캐스팅해주는 게 맞지만, PLAYER_LIST는 한 번만 응답으로 내려가도 되기 때문에, 반복문 밖으로 뺐습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?