### PR TITLE
[refactor] SSE 방 삭제 이벤트 퍼블리싱, 유저 수 조회 메서드 변경

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -216,7 +216,6 @@ public class GameService {
         request.afterChange(room, messageSender, eventPublisher, quizService);
 
         broadcastGameSetting(room);
-
     }
 
     private void validateRoomStart(Room room, UserPrincipal principal) {

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -213,16 +213,10 @@ public class GameService {
         if (!request.change(room, quizService)) {
             return;
         }
-        request.afterChange(room, messageSender);
+        request.afterChange(room, messageSender, eventPublisher, quizService);
 
         broadcastGameSetting(room);
 
-        RoomUpdatedEvent roomUpdatedEvent =
-                new RoomUpdatedEvent(
-                        room,
-                        quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId()));
-
-        eventPublisher.publishEvent(roomUpdatedEvent);
     }
 
     private void validateRoomStart(Room room, UserPrincipal principal) {

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -26,6 +26,7 @@ import io.f1.backend.domain.game.dto.response.RoomResponse;
 import io.f1.backend.domain.game.dto.response.RoomSettingResponse;
 import io.f1.backend.domain.game.dto.response.SystemNoticeResponse;
 import io.f1.backend.domain.game.event.RoomCreatedEvent;
+import io.f1.backend.domain.game.event.RoomDeletedEvent;
 import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.model.GameSetting;
 import io.f1.backend.domain.game.model.Player;
@@ -349,6 +350,8 @@ public class RoomService {
         /* 방 삭제 */
         if (room.isLastPlayer(sessionId)) {
             removeRoom(room);
+            Long roomId = room.getId();
+            eventPublisher.publishEvent(new RoomDeletedEvent(roomId));
             return;
         }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/GameSettingChanger.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/GameSettingChanger.java
@@ -3,13 +3,16 @@ package io.f1.backend.domain.game.dto.request;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
+
 import org.springframework.context.ApplicationEventPublisher;
 
 public interface GameSettingChanger {
 
     boolean change(Room room, QuizService quizService);
 
-    default void afterChange(Room room, MessageSender messageSender, ApplicationEventPublisher eventPublisher, QuizService quizService) {
-
-    }
+    default void afterChange(
+            Room room,
+            MessageSender messageSender,
+            ApplicationEventPublisher eventPublisher,
+            QuizService quizService) {}
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/GameSettingChanger.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/GameSettingChanger.java
@@ -3,10 +3,13 @@ package io.f1.backend.domain.game.dto.request;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
+import org.springframework.context.ApplicationEventPublisher;
 
 public interface GameSettingChanger {
 
     boolean change(Room room, QuizService quizService);
 
-    void afterChange(Room room, MessageSender messageSender);
+    default void afterChange(Room room, MessageSender messageSender, ApplicationEventPublisher eventPublisher, QuizService quizService) {
+
+    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
@@ -5,11 +5,13 @@ import static io.f1.backend.domain.game.websocket.WebSocketUtils.getDestination;
 
 import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.PlayerListResponse;
+import io.f1.backend.domain.game.event.RoomUpdatedEvent;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 
 @Slf4j
 public record QuizChangeRequest(long quizId) implements GameSettingChanger {
@@ -21,17 +23,24 @@ public record QuizChangeRequest(long quizId) implements GameSettingChanger {
         }
         Long questionsCount = quizService.getQuestionsCount(quizId);
         room.changeQuiz(quizId, questionsCount.intValue());
+        room.resetAllPlayerReadyStates();
         return true;
     }
 
     @Override
-    public void afterChange(Room room, MessageSender messageSender) {
-        room.resetAllPlayerReadyStates();
+    public void afterChange(Room room, MessageSender messageSender, ApplicationEventPublisher eventPublisher, QuizService quizService) {
 
         String destination = getDestination(room.getId());
         PlayerListResponse response = toPlayerListResponse(room);
 
         log.info(response.toString());
         messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, response);
+
+        RoomUpdatedEvent roomUpdatedEvent =
+            new RoomUpdatedEvent(
+                room,
+                quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId()));
+
+        eventPublisher.publishEvent(roomUpdatedEvent);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
@@ -11,6 +11,7 @@ import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.ApplicationEventPublisher;
 
 @Slf4j
@@ -28,7 +29,11 @@ public record QuizChangeRequest(long quizId) implements GameSettingChanger {
     }
 
     @Override
-    public void afterChange(Room room, MessageSender messageSender, ApplicationEventPublisher eventPublisher, QuizService quizService) {
+    public void afterChange(
+            Room room,
+            MessageSender messageSender,
+            ApplicationEventPublisher eventPublisher,
+            QuizService quizService) {
 
         String destination = getDestination(room.getId());
         PlayerListResponse response = toPlayerListResponse(room);
@@ -37,9 +42,9 @@ public record QuizChangeRequest(long quizId) implements GameSettingChanger {
         messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, response);
 
         RoomUpdatedEvent roomUpdatedEvent =
-            new RoomUpdatedEvent(
-                room,
-                quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId()));
+                new RoomUpdatedEvent(
+                        room,
+                        quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId()));
 
         eventPublisher.publishEvent(roomUpdatedEvent);
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoundChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoundChangeRequest.java
@@ -3,6 +3,7 @@ package io.f1.backend.domain.game.dto.request;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
+import org.springframework.context.ApplicationEventPublisher;
 
 public record RoundChangeRequest(int round) implements GameSettingChanger {
 
@@ -18,8 +19,4 @@ public record RoundChangeRequest(int round) implements GameSettingChanger {
         return true;
     }
 
-    @Override
-    public void afterChange(Room room, MessageSender messageSender) {
-        // 고유한 후처리 동작 없음
-    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoundChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/RoundChangeRequest.java
@@ -1,9 +1,7 @@
 package io.f1.backend.domain.game.dto.request;
 
 import io.f1.backend.domain.game.model.Room;
-import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
-import org.springframework.context.ApplicationEventPublisher;
 
 public record RoundChangeRequest(int round) implements GameSettingChanger {
 
@@ -18,5 +16,4 @@ public record RoundChangeRequest(int round) implements GameSettingChanger {
         room.changeRound(round, questionsCount.intValue());
         return true;
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/TimeLimitChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/TimeLimitChangeRequest.java
@@ -1,9 +1,7 @@
 package io.f1.backend.domain.game.dto.request;
 
 import io.f1.backend.domain.game.model.Room;
-import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
-import org.springframework.context.ApplicationEventPublisher;
 
 public record TimeLimitChangeRequest(int timeLimit) implements GameSettingChanger {
 
@@ -15,5 +13,4 @@ public record TimeLimitChangeRequest(int timeLimit) implements GameSettingChange
         room.changeTimeLimit(TimeLimit.from(timeLimit));
         return true;
     }
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/TimeLimitChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/TimeLimitChangeRequest.java
@@ -3,6 +3,7 @@ package io.f1.backend.domain.game.dto.request;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
+import org.springframework.context.ApplicationEventPublisher;
 
 public record TimeLimitChangeRequest(int timeLimit) implements GameSettingChanger {
 
@@ -15,8 +16,4 @@ public record TimeLimitChangeRequest(int timeLimit) implements GameSettingChange
         return true;
     }
 
-    @Override
-    public void afterChange(Room room, MessageSender messageSender) {
-        // 고유한 후처리 동작 없음
-    }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
@@ -48,7 +48,7 @@ public class RoomMapper {
         return new RoomSettingResponse(
                 room.getRoomSetting().roomName(),
                 room.getRoomSetting().maxUserCount(),
-                room.getPlayerSessionMap().size(),
+                room.getCurrentUserCnt(),
                 room.getRoomSetting().locked());
     }
 
@@ -71,7 +71,7 @@ public class RoomMapper {
                 room.getId(),
                 room.getRoomSetting().roomName(),
                 room.getRoomSetting().maxUserCount(),
-                room.getPlayerSessionMap().size(),
+                room.getCurrentUserCnt(),
                 room.getRoomSetting().locked(),
                 room.getState().name(),
                 quiz.getTitle(),
@@ -111,9 +111,9 @@ public class RoomMapper {
                 room.getCurrentQuestion().getId(),
                 room.getCurrentRound(),
                 Instant.now().plusSeconds(delay),
-                room.getGameSetting().getTimeLimit(),
+                room.getTimeLimit(),
                 Instant.now(),
-                room.getGameSetting().getRound());
+                room.getRound());
     }
 
     public static GameResultResponse toGameResultResponse(

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
@@ -21,7 +21,7 @@ public class SseMapper {
                         room.getId(),
                         room.getRoomSetting().roomName(),
                         room.getRoomSetting().maxUserCount(),
-                        room.getPlayerSessionMap().size(),
+                        room.getCurrentUserCnt(),
                         room.getRoomSetting().locked(),
                         room.getState().name(),
                         quiz.getTitle(),
@@ -38,7 +38,7 @@ public class SseMapper {
         RoomUpdatedPayload payload =
                 new RoomUpdatedPayload(
                         room.getId(),
-                        room.getPlayerSessionMap().size(),
+                        room.getCurrentUserCnt(),
                         room.getState().name(),
                         quiz.getTitle(),
                         quiz.getDescription(),


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #126 

## 🪐 작업 내용
- SSE 방 삭제 이벤트 퍼블리싱
- 유저 수 조회 메서드 변경
- 퀴즈 변경 시에만 SSE 업데이트 날아가도록 수정
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?