### PR TITLE
[docs] 운영 / 개발 환경 분리

### DIFF
--- a/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
@@ -15,6 +15,7 @@ public class CorsConfig {
 
         config.addAllowedOrigin("http://localhost:3000");
         config.addAllowedOrigin("https://brainrace.duckdns.org");
+		config.addAllowedOrigin("https://api.brainrace.duckdns.org");
 
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
 
         config.addAllowedOrigin("http://localhost:3000");
         config.addAllowedOrigin("https://brainrace.duckdns.org");
-		config.addAllowedOrigin("https://api.brainrace.duckdns.org");
+        config.addAllowedOrigin("https://api.brainrace.duckdns.org");
 
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
 
         config.addAllowedOrigin("http://localhost:3000");
         config.addAllowedOrigin("https://brainrace.duckdns.org");
-        config.addAllowedOrigin("https://api.brainrace.duckdns.org");
+        config.addAllowedOrigin("https://api-brainrace.duckdns.org");
 
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -68,6 +68,29 @@ server:
 spring:
   config:
     activate:
+      on-profile: dev
+
+  security:
+    user:
+      name: ${PROM_NAME}
+      password: ${PROM_PASSWORD}
+      roles: PROMETHEUS
+
+management:
+  server:
+    port: ${ACTUATOR_PORT}
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+      base-path: ${ACTUATOR_BASE_PATH}
+  endpoint:
+    prometheus:
+      access: read_only
+---
+spring:
+  config:
+    activate:
       on-profile: prod
 
   security:
@@ -75,6 +98,20 @@ spring:
       name: ${PROM_NAME}
       password: ${PROM_PASSWORD}
       roles: PROMETHEUS
+
+# TODO: Flyway 추가와 함께 설정이 필요한 항목들
+#  sql:
+#    init:
+#      mode: never
+#
+#  jpa:
+#    hibernate:
+#      ddl-auto: none
+#
+#    properties:
+#      hibernate:
+#        show_sql: false
+#        format_sql: false
 
 management:
   server:


### PR DESCRIPTION
## 🛰️ Issue Number
- #132 

## 🪐 작업 내용
현재는 동일한 backend 컨테이너에서 운영/개발 환경이 혼재한 상태입니다.
이에 대해 docker compose를 운영과 개발에 맞춰 분리 작업을 진행하고자 아래와 같은 작업을 진행했습니다.

- 개발 환경에 대한 프로필을 추가하고 프로메테우스를 통한 모니터링이 가능하도록 설정을 추가했습니다.
- 추후 Flyway 도입 시 운영 환경에서 적용이 필요한 설정들을 TODO와 함께 주석 추가해 두었습니다.
- `api-brainrace.duckdns.org` cors 설정을 추가했습니다.
  - dev 환경에 대해서 기존 포트를 통한 분리에서 도메인을 통한 환경 분리 작업을 진행하고자 추가했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?