### PR TITLE
[refactor] 퀴즈, 문제 수정 API 리팩토링

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -95,7 +95,6 @@ public class GameService {
     @EventListener
     public void onCorrectAnswer(GameCorrectAnswerEvent event) {
 
-
         Room room = event.room();
         log.debug("Correct Answer! " + room.getCurrentRound());
         String sessionId = event.sessionId();

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -95,7 +95,9 @@ public class GameService {
     @EventListener
     public void onCorrectAnswer(GameCorrectAnswerEvent event) {
 
+
         Room room = event.room();
+        log.debug("Correct Answer! " + room.getCurrentRound());
         String sessionId = event.sessionId();
         ChatMessage chatMessage = event.chatMessage();
         String answer = event.answer();
@@ -135,6 +137,8 @@ public class GameService {
     @EventListener
     public void onTimeout(GameTimeoutEvent event) {
         Room room = event.room();
+        log.debug("Timeout! " + room.getCurrentRound());
+
         String destination = getDestination(room.getId());
 
         messageSender.sendBroadcast(

--- a/backend/src/main/java/io/f1/backend/domain/game/app/TimerService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/TimerService.java
@@ -4,8 +4,8 @@ import io.f1.backend.domain.game.event.GameTimeoutEvent;
 import io.f1.backend.domain.game.model.Room;
 
 import lombok.RequiredArgsConstructor;
-
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/io/f1/backend/domain/game/app/TimerService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/TimerService.java
@@ -5,12 +5,14 @@ import io.f1.backend.domain.game.model.Room;
 
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TimerService {
@@ -18,6 +20,7 @@ public class TimerService {
     private final ApplicationEventPublisher eventPublisher;
 
     public void startTimer(Room room, int delaySec) {
+        log.debug("Starting timer : round " + room.getCurrentRound());
         cancelTimer(room);
 
         ScheduledFuture<?> timer =
@@ -43,6 +46,7 @@ public class TimerService {
 
     public boolean cancelTimer(Room room) {
         // 정답 맞혔어요 ~ 타이머 캔슬 부탁
+        log.debug("Canceling timer : round " + room.getCurrentRound());
         ScheduledFuture<?> timer = room.getTimer();
         if (timer != null && !timer.isDone()) {
             return timer.cancel(false);

--- a/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
@@ -20,21 +20,6 @@ public class QuestionController {
 
     private final QuestionService questionService;
 
-    @PutMapping("/{questionId}")
-    public ResponseEntity<Void> updateQuestion(
-            @PathVariable Long questionId, @RequestBody QuestionUpdateRequest request) {
-
-        if (request.content() != null) {
-            questionService.updateQuestionContent(questionId, request.content());
-        }
-
-        if (request.content() != null) {
-            questionService.updateQuestionAnswer(questionId, request.answer());
-        }
-
-        return ResponseEntity.noContent().build();
-    }
-
     @DeleteMapping("/{questionId}")
     public ResponseEntity<Void> deleteQuestion(@PathVariable Long questionId) {
         questionService.deleteQuestion(questionId);

--- a/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/api/QuestionController.java
@@ -1,15 +1,12 @@
 package io.f1.backend.domain.question.api;
 
 import io.f1.backend.domain.question.app.QuestionService;
-import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -12,17 +12,12 @@ import io.f1.backend.domain.question.entity.Question;
 import io.f1.backend.domain.question.entity.TextQuestion;
 import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.global.exception.CustomException;
-import io.f1.backend.global.exception.errorcode.AuthErrorCode;
 import io.f1.backend.global.exception.errorcode.QuestionErrorCode;
-import io.f1.backend.global.security.enums.Role;
-import io.f1.backend.global.util.SecurityUtils;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -46,14 +41,13 @@ public class QuestionService {
     public void updateQuestions(QuestionUpdateRequest request) {
 
         Question question =
-            questionRepository
-                .findById(request.id())
-                .orElseThrow(
-                    () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
+                questionRepository
+                        .findById(request.id())
+                        .orElseThrow(
+                                () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
         updateQuestionContent(question, request.content());
         updateQuestionAnswer(question, request.answer());
-
     }
 
     private void updateQuestionContent(Question question, String content) {

--- a/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/app/QuestionService.java
@@ -42,24 +42,13 @@ public class QuestionService {
 
         Question question =
                 questionRepository
-                        .findById(request.id())
+                        .findById(request.getId())
                         .orElseThrow(
                                 () -> new CustomException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
-        updateQuestionContent(question, request.content());
-        updateQuestionAnswer(question, request.answer());
-    }
-
-    private void updateQuestionContent(Question question, String content) {
-        validateContent(content);
-
         TextQuestion textQuestion = question.getTextQuestion();
-        textQuestion.changeContent(content);
-    }
-
-    private void updateQuestionAnswer(Question question, String answer) {
-        validateAnswer(answer);
-        question.changeAnswer(answer);
+        textQuestion.changeContent(request.getContent());
+        question.changeAnswer(request.getAnswer());
     }
 
     @Transactional
@@ -74,17 +63,5 @@ public class QuestionService {
         verifyUserAuthority(question.getQuiz());
 
         questionRepository.delete(question);
-    }
-
-    private void validateAnswer(String answer) {
-        if (answer.trim().length() < 5 || answer.trim().length() > 30) {
-            throw new CustomException(QuestionErrorCode.INVALID_ANSWER_LENGTH);
-        }
-    }
-
-    private void validateContent(String content) {
-        if (content.trim().length() < 5 || content.trim().length() > 30) {
-            throw new CustomException(QuestionErrorCode.INVALID_CONTENT_LENGTH);
-        }
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
@@ -1,3 +1,3 @@
 package io.f1.backend.domain.question.dto;
 
-public record QuestionUpdateRequest(String content, String answer) {}
+public record QuestionUpdateRequest(Long id, String content, String answer) {}

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
@@ -1,3 +1,22 @@
 package io.f1.backend.domain.question.dto;
 
-public record QuestionUpdateRequest(Long id, String content, String answer) {}
+import io.f1.backend.global.validation.TrimmedSize;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionUpdateRequest {
+
+    private Long id;
+
+    @TrimmedSize(min = 5, max = 30)
+    @NotBlank(message = "문제를 입력해주세요.")
+    private String content;
+
+    @TrimmedSize(min = 1, max = 30)
+    @NotBlank(message = "정답을 입력해주세요.")
+    private String answer;
+}

--- a/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/question/dto/QuestionUpdateRequest.java
@@ -1,7 +1,9 @@
 package io.f1.backend.domain.question.dto;
 
 import io.f1.backend.global.validation.TrimmedSize;
+
 import jakarta.validation.constraints.NotBlank;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -59,13 +59,7 @@ public class QuizController {
             @RequestPart(required = false) MultipartFile thumbnailFile,
             @RequestPart QuizUpdateRequest request) {
 
-        if (request.title() != null) {
-            quizService.updateQuizTitle(quizId, request.title());
-        }
-
-        if (request.description() != null) {
-            quizService.updateQuizDesc(quizId, request.description());
-        }
+        quizService.updateQuizAndQuestions(quizId, request);
 
         if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
             quizService.updateThumbnail(quizId, thumbnailFile);

--- a/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/api/QuizController.java
@@ -57,7 +57,7 @@ public class QuizController {
     public ResponseEntity<Void> updateQuiz(
             @PathVariable Long quizId,
             @RequestPart(required = false) MultipartFile thumbnailFile,
-            @RequestPart QuizUpdateRequest request) {
+            @Valid @RequestPart QuizUpdateRequest request) {
 
         quizService.updateQuizAndQuestions(quizId, request);
 

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -158,24 +158,15 @@ public class QuizService {
 
         verifyUserAuthority(quiz);
 
-        updateQuizTitle(quiz, request.title());
-        updateQuizDesc(quiz, request.description());
+        quiz.changeTitle(request.getTitle());
+        quiz.changeDescription(request.getDescription());
 
-        List<QuestionUpdateRequest> questionReqList = request.questions();
+
+        List<QuestionUpdateRequest> questionReqList = request.getQuestions();
 
         for (QuestionUpdateRequest questionReq : questionReqList) {
             questionService.updateQuestions(questionReq);
         }
-    }
-
-    private void updateQuizTitle(Quiz quiz, String title) {
-        validateTitle(title);
-        quiz.changeTitle(title);
-    }
-
-    private void updateQuizDesc(Quiz quiz, String description) {
-        validateDesc(description);
-        quiz.changeDescription(description);
     }
 
     @Transactional
@@ -193,18 +184,6 @@ public class QuizService {
 
         deleteThumbnailFile(quiz.getThumbnailUrl());
         quiz.changeThumbnailUrl(newThumbnailPath);
-    }
-
-    private void validateDesc(String desc) {
-        if (desc.trim().length() < 10 || desc.trim().length() > 50) {
-            throw new CustomException(QuizErrorCode.INVALID_DESC_LENGTH);
-        }
-    }
-
-    private void validateTitle(String title) {
-        if (title.trim().length() < 2 || title.trim().length() > 30) {
-            throw new CustomException(QuizErrorCode.INVALID_TITLE_LENGTH);
-        }
     }
 
     private void deleteThumbnailFile(String oldFilename) {

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -152,9 +152,9 @@ public class QuizService {
     @Transactional
     public void updateQuizAndQuestions(Long quizId, QuizUpdateRequest request) {
         Quiz quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
+                quizRepository
+                        .findById(quizId)
+                        .orElseThrow(() -> new CustomException(QuizErrorCode.QUIZ_NOT_FOUND));
 
         verifyUserAuthority(quiz);
 
@@ -163,7 +163,7 @@ public class QuizService {
 
         List<QuestionUpdateRequest> questionReqList = request.questions();
 
-        for(QuestionUpdateRequest questionReq : questionReqList) {
+        for (QuestionUpdateRequest questionReq : questionReqList) {
             questionService.updateQuestions(questionReq);
         }
     }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/app/QuizService.java
@@ -161,7 +161,6 @@ public class QuizService {
         quiz.changeTitle(request.getTitle());
         quiz.changeDescription(request.getDescription());
 
-
         List<QuestionUpdateRequest> questionReqList = request.getQuestions();
 
         for (QuestionUpdateRequest questionReq : questionReqList) {

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
@@ -1,6 +1,8 @@
 package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
+
 import java.util.List;
 
-public record QuizUpdateRequest(String title, String description, List<QuestionUpdateRequest> questions) {}
+public record QuizUpdateRequest(
+        String title, String description, List<QuestionUpdateRequest> questions) {}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
@@ -2,7 +2,27 @@ package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
 
+import io.f1.backend.global.validation.TrimmedSize;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record QuizUpdateRequest(
-        String title, String description, List<QuestionUpdateRequest> questions) {}
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuizUpdateRequest {
+
+    @TrimmedSize(min = 2, max = 30)
+    @NotBlank(message = "퀴즈 제목을 설정해주세요.")
+    private String title;
+
+    @TrimmedSize(min = 10, max = 50)
+    @NotBlank(message = "퀴즈 설명을 적어주세요.")
+    private String description;
+
+    @Size(min = 10, max = 80, message = "문제는 최소 10개, 최대 80개로 정해주세요.")
+    private List<QuestionUpdateRequest> questions;
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
@@ -1,14 +1,16 @@
 package io.f1.backend.domain.quiz.dto;
 
 import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
-
 import io.f1.backend.global.validation.TrimmedSize;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,5 +26,4 @@ public class QuizUpdateRequest {
 
     @Size(min = 10, max = 80, message = "문제는 최소 10개, 최대 80개로 정해주세요.")
     private List<QuestionUpdateRequest> questions;
-
 }

--- a/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/quiz/dto/QuizUpdateRequest.java
@@ -1,3 +1,6 @@
 package io.f1.backend.domain.quiz.dto;
 
-public record QuizUpdateRequest(String title, String description) {}
+import io.f1.backend.domain.question.dto.QuestionUpdateRequest;
+import java.util.List;
+
+public record QuizUpdateRequest(String title, String description, List<QuestionUpdateRequest> questions) {}


### PR DESCRIPTION
## 🛰️ Issue Number
- #142 

## 🪐 작업 내용

1. 퀴즈와 문제가 하나의 API로 수정될 수 있도록 수정했습니다. 
2. request에는 기존에 저장된 값 + 바뀐 값 모든 필드의 값들이 전달되어 옵니다. 
- 그래서 기존 메서드에서 유효성 검사를 하는 것에서 DTO에 @Valid 검사로 변경했습니다.
3. 썸네일은 프론트에서 변경감지로 변경되었을 때만 보내주도록 합니다. 
4. 이외의 퀴즈 정보, 문제, 답은 프론트에서 따로 변경감지 하지 않고, 백에서 업데이트합니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?