### PR TITLE
[feat] SSE 하트비트 추가

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -59,7 +59,7 @@ public class GameService {
     private final RoomRepository roomRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    @DistributedLock(prefix = "room", key = "#roomId", waitTime = 0)
+    @DistributedLock(prefix = "room", key = "#roomId")
     public void gameStart(Long roomId, UserPrincipal principal) {
 
         String destination = getDestination(roomId);

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
@@ -21,7 +21,7 @@ public class SseService {
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     public SseEmitter subscribe() {
-        SseEmitter emitter = new SseEmitter(5_000L);
+        SseEmitter emitter = new SseEmitter(1_800_000L);
         emitterRepository.save(emitter);
 
         try {
@@ -44,16 +44,12 @@ public class SseService {
     }
 
     private void startHeartBeat(SseEmitter emitter) {
-        scheduler.scheduleAtFixedRate(
-                () -> {
-                    try {
-                        emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
-                    } catch (IOException e) {
-                        emitterRepository.remove(emitter);
-                    }
-                },
-                5,
-                60,
-                TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(() -> {
+            try {
+                emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
+            } catch (IOException e) {
+                emitterRepository.remove(emitter);
+            }
+        }, 5, 30, TimeUnit.SECONDS);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
@@ -44,16 +44,12 @@ public class SseService {
     }
 
     private void startHeartBeat(SseEmitter emitter) {
-        scheduler.scheduleAtFixedRate(
-                () -> {
-                    try {
-                        emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
-                    } catch (IOException e) {
-                        emitterRepository.remove(emitter);
-                    }
-                },
-                5,
-                30,
-                TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(() -> {
+            try {
+                emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
+            } catch (IOException e) {
+                emitterRepository.remove(emitter);
+            }
+        }, 5, 60, TimeUnit.SECONDS);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
@@ -44,12 +44,16 @@ public class SseService {
     }
 
     private void startHeartBeat(SseEmitter emitter) {
-        scheduler.scheduleAtFixedRate(() -> {
-            try {
-                emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
-            } catch (IOException e) {
-                emitterRepository.remove(emitter);
-            }
-        }, 5, 60, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(
+                () -> {
+                    try {
+                        emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
+                    } catch (IOException e) {
+                        emitterRepository.remove(emitter);
+                    }
+                },
+                5,
+                60,
+                TimeUnit.SECONDS);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/app/SseService.java
@@ -44,12 +44,16 @@ public class SseService {
     }
 
     private void startHeartBeat(SseEmitter emitter) {
-        scheduler.scheduleAtFixedRate(() -> {
-            try {
-                emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
-            } catch (IOException e) {
-                emitterRepository.remove(emitter);
-            }
-        }, 5, 30, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(
+                () -> {
+                    try {
+                        emitter.send(SseEmitter.event().name("heartbeat").data("sse-alive"));
+                    } catch (IOException e) {
+                        emitterRepository.remove(emitter);
+                    }
+                },
+                5,
+                30,
+                TimeUnit.SECONDS);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/store/SseEmitterRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/store/SseEmitterRepository.java
@@ -13,18 +13,16 @@ public class SseEmitterRepository {
 
     public void save(SseEmitter emitter) {
         emitters.add(emitter);
-        // 연결종료 객체정리
+
         emitter.onCompletion(() -> emitters.remove(emitter));
         emitter.onTimeout(() -> emitters.remove(emitter));
         emitter.onError(error -> emitters.remove(emitter));
     }
 
-    // 연결 종료 객체 정리
     public void remove(SseEmitter emitter) {
         emitters.remove(emitter);
     }
 
-    // 브로드캐스팅
     public List<SseEmitter> getAll() {
         return emitters;
     }


### PR DESCRIPTION
## 🛰️ Issue Number
Closes #144 

## 🪐 작업 내용
### SSE 하트비트 추가
- nginx의 proxy_connect_timeout의 디폴트가 60초로 되어있어, 기본 하트비트의 시간을 30초로 설정해놓았습니다. _Ref(1)_
<img width="973" height="158" alt="스크린샷 2025-07-29 오후 3 38 28" src="https://github.com/user-attachments/assets/c63bc03c-65e8-414c-82e1-e20dc04d343a" />
위 사진 처럼, SSE가 타임아웃이 되기전까지 30초 마다 하트비트를 보내게됩니다.

### gameStart의 락 대기타임 디폴트값으로 변경
- 기존 waitTime이 다른 메서드의 락대기에 적용이 된다고 PR을 잘못올린것 같습니다. 어노테이션의 waitTime은 어노테이션이 적용되는 메서드에 한해 락 대기시간이 적용됩니다!😭🙈

## 📚 Reference
(1) https://13months.tistory.com/651

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?