### PR TITLE
[fix] 게임 종료 후 랭킹 점수 반영 예외 수정

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
@@ -1,5 +1,6 @@
 package io.f1.backend.domain.stat.dao;
 
+import static java.lang.Long.parseLong;
 import static java.util.Objects.requireNonNull;
 
 import io.f1.backend.domain.stat.dto.StatPageResponse;
@@ -50,8 +51,8 @@ public class StatRedisRepository {
 
         // stat:user:{id}
         hashOps.put(statUserKey, "nickname", stat.nickname());
-        hashOps.put(statUserKey, "totalGames", stat.totalGames());
-        hashOps.put(statUserKey, "winningGames", stat.winningGames());
+        hashOps.put(statUserKey, "totalGames", String.valueOf(stat.totalGames()));
+        hashOps.put(statUserKey, "winningGames", String.valueOf(stat.winningGames()));
 
         // stat:rank
         zSetOps.add(STAT_RANK, stat.userId(), stat.score());
@@ -135,8 +136,8 @@ public class StatRedisRepository {
         return new StatResponse(
                 rankValue,
                 (String) statUserMap.get("nickname"),
-                (long) statUserMap.get("totalGames"),
-                (long) statUserMap.get("winningGames"),
+				parseLong((String) statUserMap.get("totalGames")),
+                parseLong((String) statUserMap.get("winningGames")),
                 requireNonNull(rank.getScore()).longValue());
     }
 
@@ -166,8 +167,8 @@ public class StatRedisRepository {
         return new MyPageInfo(
                 (String) statMap.get("nickname"),
                 rank + 1,
-                (long) statMap.get("totalGames"),
-                (long) statMap.get("winningGames"),
+				parseLong((String) statMap.get("totalGames")),
+				parseLong((String) statMap.get("winningGames")),
                 score.longValue());
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
@@ -136,7 +136,7 @@ public class StatRedisRepository {
         return new StatResponse(
                 rankValue,
                 (String) statUserMap.get("nickname"),
-				parseLong((String) statUserMap.get("totalGames")),
+                parseLong((String) statUserMap.get("totalGames")),
                 parseLong((String) statUserMap.get("winningGames")),
                 requireNonNull(rank.getScore()).longValue());
     }
@@ -167,8 +167,8 @@ public class StatRedisRepository {
         return new MyPageInfo(
                 (String) statMap.get("nickname"),
                 rank + 1,
-				parseLong((String) statMap.get("totalGames")),
-				parseLong((String) statMap.get("winningGames")),
+                parseLong((String) statMap.get("totalGames")),
+                parseLong((String) statMap.get("winningGames")),
                 score.longValue());
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/RedisConfig.java
@@ -24,6 +24,8 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         redisConnectionFactory.getConnection().serverCommands().flushAll();


### PR DESCRIPTION
## 🛰️ Issue Number
- #169 

## 🪐 작업 내용
게임 종료 후 랭킹 점수 반영에서 예외가 발생하며 정상 종료가 되지 않고 랭킹도 업데이트되지 않는 문제가 존재했습니다.

랭킹 점수 반영의 예외는 Redis의 HashValue 값 중 winningGames와 totalGames가 Long Object 형태로 존재하면서 HashValue의 increase 연산이 정상 진행되지 않아 발생했습니다.

이에 따라 아래와 같은 내용을 수정했습니다.
- RedisTemplate의 HashKey 및 HashValue의 Serializer를 StringRedisSerializer로 변경
- HashValue에 Long 값 저장 및 불러오기 시 String을 기준으로 수행하도록 변경

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?