### PR TITLE
[feat] 하트비트 구현 

### DIFF
--- a/backend/src/main/java/io/f1/backend/BackendApplication.java
+++ b/backend/src/main/java/io/f1/backend/BackendApplication.java
@@ -6,7 +6,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableConfigurationProperties(OAuthRedirectProperties.class)

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/MessageType.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/MessageType.java
@@ -11,5 +11,6 @@ public enum MessageType {
     RANK_UPDATE,
     QUESTION_START,
     GAME_RESULT,
-    EXIT_SUCCESS
+    EXIT_SUCCESS,
+    HEARTBEAT
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/response/HeartbeatResponse.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/response/HeartbeatResponse.java
@@ -1,0 +1,5 @@
+package io.f1.backend.domain.game.dto.response;
+
+public record HeartbeatResponse (String direction){
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -5,7 +5,6 @@ import static io.f1.backend.domain.game.websocket.WebSocketUtils.getUserDestinat
 import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.HeartbeatResponse;
-import io.f1.backend.domain.user.dto.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,10 +13,8 @@ import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpUser;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
-import java.security.Principal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -61,25 +58,25 @@ public class HeartbeatMonitor {
                 new HeartbeatResponse(DIRECTION),
                 user.getName());
 
-        //todo FE 개발 될때까지 주석 처리
-//        missedPongCounter.merge(sessionId, 1, Integer::sum);
-//        int missedCnt = missedPongCounter.get(sessionId);
-//
-//        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
-//        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
-//
-//            Principal principal = user.getPrincipal();
-//
-//            if (principal instanceof UsernamePasswordAuthenticationToken token
-//                    && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
-//
-//                Long userId = userPrincipal.getUserId();
-//                Long roomId = roomService.getRoomIdByUserId(userId);
-//
-//                roomService.disconnectOrExitRoom(roomId, userPrincipal);
-//            }
-//            missedPongCounter.remove(sessionId);
-//        }
+        // todo FE 개발 될때까지 주석 처리
+        //        missedPongCounter.merge(sessionId, 1, Integer::sum);
+        //        int missedCnt = missedPongCounter.get(sessionId);
+        //
+        //        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
+        //        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
+        //
+        //            Principal principal = user.getPrincipal();
+        //
+        //            if (principal instanceof UsernamePasswordAuthenticationToken token
+        //                    && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
+        //
+        //                Long userId = userPrincipal.getUserId();
+        //                Long roomId = roomService.getRoomIdByUserId(userId);
+        //
+        //                roomService.disconnectOrExitRoom(roomId, userPrincipal);
+        //            }
+        //            missedPongCounter.remove(sessionId);
+        //        }
     }
 
     public void resetMissedPongCount(String sessionId) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -48,7 +48,7 @@ public class HeartbeatMonitor {
     private void handleSessionHeartbeat(SimpUser user, SimpSession session) {
         String sessionId = session.getId();
 
-        /* pong */
+        /* ping */
         messageSender.sendPersonal(getUserDestination(),
             MessageType.HEARTBEAT, new HeartbeatResponse(DIRECTION), user.getName());
 
@@ -68,7 +68,7 @@ public class HeartbeatMonitor {
 
                 roomService.disconnectOrExitRoom(roomId, userPrincipal);
             }
-            missedPongCounter.remove(sessionId);
+            cleanSession(sessionId);
         }
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -1,0 +1,83 @@
+package io.f1.backend.domain.game.websocket;
+
+import static io.f1.backend.domain.game.websocket.WebSocketUtils.getUserDestination;
+
+import io.f1.backend.domain.game.app.RoomService;
+import io.f1.backend.domain.game.dto.MessageType;
+import io.f1.backend.domain.game.dto.response.HeartbeatResponse;
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.user.SimpSession;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HeartbeatMonitor {
+
+    private static final String DIRECTION = "serverToClient";
+    private static final int MAX_MISSED_HEARTBEATS = 3;
+    private static final long HEARTBEAT_CHECK_INTERVAL_MS = 15000L;
+
+    private final Map<String, Integer> missedPongCounter = new ConcurrentHashMap<>();
+
+    private final MessageSender messageSender;
+    private final RoomService roomService;
+    private final SimpUserRegistry simpUserRegistry;
+
+    @Scheduled(fixedDelay = HEARTBEAT_CHECK_INTERVAL_MS)
+    public void monitorClientHeartbeat() {
+        /* user 없으면 skip */
+        if (simpUserRegistry.getUserCount() == 0) {
+            return;
+        }
+
+        simpUserRegistry.getUsers().forEach(user ->
+            user.getSessions().forEach(session -> handleSessionHeartbeat(user, session)));
+
+    }
+
+    private void handleSessionHeartbeat(SimpUser user, SimpSession session) {
+        String sessionId = session.getId();
+
+        /* pong */
+        messageSender.sendPersonal(getUserDestination(),
+            MessageType.HEARTBEAT, new HeartbeatResponse(DIRECTION), user.getName());
+
+        missedPongCounter.merge(sessionId, 1, Integer::sum);
+        int missedCnt = missedPongCounter.get(sessionId);
+
+        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
+        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
+
+            Principal principal = user.getPrincipal();
+
+            if (principal instanceof UsernamePasswordAuthenticationToken token &&
+                token.getPrincipal() instanceof UserPrincipal userPrincipal) {
+
+                Long userId = userPrincipal.getUserId();
+                Long roomId = roomService.getRoomIdByUserId(userId);
+
+                roomService.disconnectOrExitRoom(roomId, userPrincipal);
+            }
+            missedPongCounter.remove(sessionId);
+        }
+    }
+
+    public void resetMissedPongCount(String sessionId) {
+        missedPongCounter.put(sessionId, 0);
+    }
+
+    public void cleanSession(String sessionId) {
+        missedPongCounter.remove(sessionId);
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -51,7 +51,7 @@ public class HeartbeatMonitor {
     private void handleSessionHeartbeat(SimpUser user, SimpSession session) {
         String sessionId = session.getId();
 
-        /* pong */
+        /* ping */
         messageSender.sendPersonal(
                 getUserDestination(),
                 MessageType.HEARTBEAT,
@@ -75,7 +75,7 @@ public class HeartbeatMonitor {
         //
         //                roomService.disconnectOrExitRoom(roomId, userPrincipal);
         //            }
-        //            missedPongCounter.remove(sessionId);
+        //            cleanSession(sessionId);
         //        }
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -61,24 +61,25 @@ public class HeartbeatMonitor {
                 new HeartbeatResponse(DIRECTION),
                 user.getName());
 
-        missedPongCounter.merge(sessionId, 1, Integer::sum);
-        int missedCnt = missedPongCounter.get(sessionId);
-
-        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
-        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
-
-            Principal principal = user.getPrincipal();
-
-            if (principal instanceof UsernamePasswordAuthenticationToken token
-                    && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
-
-                Long userId = userPrincipal.getUserId();
-                Long roomId = roomService.getRoomIdByUserId(userId);
-
-                roomService.disconnectOrExitRoom(roomId, userPrincipal);
-            }
-            missedPongCounter.remove(sessionId);
-        }
+        //todo FE 개발 될때까지 주석 처리
+//        missedPongCounter.merge(sessionId, 1, Integer::sum);
+//        int missedCnt = missedPongCounter.get(sessionId);
+//
+//        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
+//        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
+//
+//            Principal principal = user.getPrincipal();
+//
+//            if (principal instanceof UsernamePasswordAuthenticationToken token
+//                    && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
+//
+//                Long userId = userPrincipal.getUserId();
+//                Long roomId = roomService.getRoomIdByUserId(userId);
+//
+//                roomService.disconnectOrExitRoom(roomId, userPrincipal);
+//            }
+//            missedPongCounter.remove(sessionId);
+//        }
     }
 
     public void resetMissedPongCount(String sessionId) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/MessageSender.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/MessageSender.java
@@ -2,10 +2,7 @@ package io.f1.backend.domain.game.websocket;
 
 import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.DefaultWebSocketResponse;
-import io.f1.backend.domain.user.dto.UserPrincipal;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -21,8 +18,8 @@ public class MessageSender {
     }
 
     public <T> void sendPersonal(
-            String destination, MessageType type, T message, UserPrincipal principal) {
+            String destination, MessageType type, T message, String principalName) {
         messagingTemplate.convertAndSendToUser(
-                principal.getName(), destination, new DefaultWebSocketResponse<>(type, message));
+            principalName, destination, new DefaultWebSocketResponse<>(type, message));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/WebSocketUtils.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/WebSocketUtils.java
@@ -14,7 +14,16 @@ public class WebSocketUtils {
         return (UserPrincipal) auth.getPrincipal();
     }
 
+    public static String getSessionId(Message<?> message) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        return accessor.getSessionId();
+    }
+
     public static String getDestination(Long roomId) {
         return "/sub/room/" + roomId;
+    }
+
+    public static String getUserDestination() {
+        return "/queue";
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
@@ -39,7 +39,7 @@ public class GameSocketController {
     public void reconnect(@DestinationVariable Long roomId, Message<?> message) {
 
         UserPrincipal principal = getSessionUser(message);
-        roomService.changeConnectedStatus(principal.getUserId(), ConnectionState.CONNECTED);
+        roomService.changeConnectedStatus(roomId,principal.getUserId(), ConnectionState.CONNECTED);
         roomService.reconnectSendResponse(roomId, principal);
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
@@ -20,6 +20,7 @@ public class HeartbeatController {
     public void handlePong(Message<?> message) {
         String sessionId = getSessionId(message);
 
-        heartbeatMonitor.resetMissedPongCount(sessionId);
+        //todo FE 개발 될때까지 주석 처리
+        //heartbeatMonitor.resetMissedPongCount(sessionId);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
@@ -20,7 +20,7 @@ public class HeartbeatController {
     public void handlePong(Message<?> message) {
         String sessionId = getSessionId(message);
 
-        //todo FE 개발 될때까지 주석 처리
-        //heartbeatMonitor.resetMissedPongCount(sessionId);
+        // todo FE 개발 될때까지 주석 처리
+        // heartbeatMonitor.resetMissedPongCount(sessionId);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
@@ -1,0 +1,24 @@
+package io.f1.backend.domain.game.websocket.controller;
+
+import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionId;
+
+import io.f1.backend.domain.game.websocket.HeartbeatMonitor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class HeartbeatController {
+
+    private final HeartbeatMonitor heartbeatMonitor;
+
+    @MessageMapping("/heartbeat/pong")
+    public void handlePong(Message<?> message) {
+        String sessionId = getSessionId(message);
+
+        heartbeatMonitor.resetMissedPongCount(sessionId);
+    }
+
+}

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -33,8 +33,8 @@ public class WebsocketEventListener {
 
         Long userId = principal.getUserId();
 
-        //todo FE 개발 될때까지 주석 처리
-        //heartbeatMonitor.cleanSession(event.getSessionId());
+        // todo FE 개발 될때까지 주석 처리
+        // heartbeatMonitor.cleanSession(event.getSessionId());
 
         /* 정상 로직 */
         if (!roomService.isUserInAnyRoom(userId)) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -33,7 +33,8 @@ public class WebsocketEventListener {
 
         Long userId = principal.getUserId();
 
-        heartbeatMonitor.cleanSession(event.getSessionId());
+        //todo FE 개발 될때까지 주석 처리
+        //heartbeatMonitor.cleanSession(event.getSessionId());
 
         /* 정상 로직 */
         if (!roomService.isUserInAnyRoom(userId)) {

--- a/backend/src/main/java/io/f1/backend/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/WebSocketConfig.java
@@ -1,7 +1,6 @@
 package io.f1.backend.global.config;
 
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -26,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub", "/queue");
+        registry.enableSimpleBroker("/sub", "/queue").setHeartbeatValue(new long[]{0, 0});
         registry.setApplicationDestinationPrefixes("/pub");
 
         registry.setUserDestinationPrefix("/user");


### PR DESCRIPTION
## 🛰️ Issue Number
- #118 

## 🪐 작업 내용

- 클라이언트에서 3번이상 응답이 안올 경우 유저 퇴장처리를 하기위해 `stomp`의 기본 하트비트를 설정하지않고 send 요청으로 하트비트를 구현(`ping-pong`)
- 15초 간격으로 `ping` 을 보내면서 카운트를 1 증가시키고,  `pong` 응답이 오면 카운트를 0으로 초기화.
- 이때 `ping` 을 보내는건 스케줄러로 구현하였고 연결된 세션이 있을때만 동작 
- 테스트는 임시로 FE코드를 수정하였음. 

15초 간격으로 `ping`보내고 `pong` 받기
<img width="1367" height="177" alt="image" src="https://github.com/user-attachments/assets/65be686e-93be-4003-903c-1eee0c8e4508" />

- FE에서도 마찬가지로 ping 응답이 일정 간격을 두고 3번이상 오지 않으면 `deactivate()`하는 로직 구현 필요 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?