### PR TITLE
[fix] 마이페이지 DTO 값 순서 변경

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRedisRepository.java
@@ -166,8 +166,8 @@ public class StatRedisRepository {
         return new MyPageInfo(
                 (String) statMap.get("nickname"),
                 rank + 1,
+                score.longValue(),
                 (long) statMap.get("totalGames"),
-                (long) statMap.get("winningGames"),
-                score.longValue());
+                (long) statMap.get("winningGames"));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepositoryAdapter.java
+++ b/backend/src/main/java/io/f1/backend/domain/stat/dao/StatRepositoryAdapter.java
@@ -109,7 +109,7 @@ public class StatRepositoryAdapter implements StatRepository {
         long rank = jpaRepository.countByScoreGreaterThan(stat.score()) + 1;
 
         return new MyPageInfo(
-                stat.nickname(), rank, stat.totalGames(), stat.winningGames(), stat.score());
+                stat.nickname(), rank, stat.score(), stat.totalGames(), stat.winningGames());
     }
 
     private StatWithUserSummary findStatByUserId(long userId) {


### PR DESCRIPTION
## 🛰️ Issue Number
- #173 

## 🪐 작업 내용
- 마이페이지 조회 시 DTO 값의 순서를 잘못되어 수정했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?