### PR TITLE
[refactor] redisson 적용 

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -47,15 +47,17 @@ import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 import io.f1.backend.global.lock.DistributedLock;
 import io.f1.backend.global.lock.LockExecutor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -74,7 +76,6 @@ public class RoomService {
 
     public static final String ROOM_LOCK_PREFIX = "room";
     public static final String USER_LOCK_PREFIX = "user";
-
 
     public RoomCreateResponse saveRoom(RoomCreateRequest request) {
 
@@ -97,8 +98,10 @@ public class RoomService {
         roomRepository.saveRoom(room);
 
         /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, host.getId(),
-            () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                host.getId(),
+                () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
         eventPublisher.publishEvent(new RoomCreatedEvent(room, quiz));
 
@@ -112,13 +115,14 @@ public class RoomService {
         Room room = findRoom(roomId);
 
         /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, getCurrentUserId(),
-            () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                getCurrentUserId(),
+                () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
-        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
-            () -> performEnterRoomLogic(request));
+        lockExecutor.executeWithLock(
+                ROOM_LOCK_PREFIX, roomId, () -> performEnterRoomLogic(request));
     }
-
 
     private void performEnterRoomLogic(RoomValidationRequest request) {
 
@@ -155,9 +159,10 @@ public class RoomService {
         Long joinedRoomId = getRoomIdByUserId(userId);
 
         if (joinedRoomId != null && !room.isSameRoom(joinedRoomId)) {
-            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, joinedRoomId,
-                () -> disconnectOrExitRoom(joinedRoomId, userPrincipal));
-
+            lockExecutor.executeWithLock(
+                    ROOM_LOCK_PREFIX,
+                    joinedRoomId,
+                    () -> disconnectOrExitRoom(joinedRoomId, userPrincipal));
         }
     }
 
@@ -165,66 +170,79 @@ public class RoomService {
 
         Long userId = principal.getUserId();
 
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId, () -> {
-            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                userId,
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                Room room = findRoom(roomId);
 
-                Room room = findRoom(roomId);
+                                if (!room.hasPlayer(userId)) {
+                                    throw new CustomException(RoomErrorCode.ROOM_ENTER_REQUIRED);
+                                }
 
-                if (!room.hasPlayer(userId)) {
-                    throw new CustomException(RoomErrorCode.ROOM_ENTER_REQUIRED);
-                }
+                                /* 재연결 */
+                                if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
+                                    changeConnectedStatus(
+                                            roomId, userId, ConnectionState.CONNECTED);
+                                    cancelTask(userId);
+                                    reconnectSendResponse(roomId, principal);
+                                    return;
+                                }
 
-                /* 재연결 */
-                if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
-                    changeConnectedStatus(roomId, userId, ConnectionState.CONNECTED);
-                    cancelTask(userId);
-                    reconnectSendResponse(roomId, principal);
-                    return;
-                }
+                                Player player = createPlayer(principal);
 
-                Player player = createPlayer(principal);
+                                RoomSettingResponse roomSettingResponse =
+                                        toRoomSettingResponse(room);
 
-                RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
+                                Long quizId = room.getGameSetting().getQuizId();
+                                Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                Long quizId = room.getGameSetting().getQuizId();
-                Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+                                GameSettingResponse gameSettingResponse =
+                                        toGameSettingResponse(room.getGameSetting(), quiz);
 
-                GameSettingResponse gameSettingResponse =
-                    toGameSettingResponse(room.getGameSetting(), quiz);
+                                PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
-                PlayerListResponse playerListResponse = toPlayerListResponse(room);
+                                SystemNoticeResponse systemNoticeResponse =
+                                        ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
 
-                SystemNoticeResponse systemNoticeResponse =
-                    ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
+                                String destination = getDestination(roomId);
 
-                String destination = getDestination(roomId);
+                                userRoomRepository.addUser(player, room);
 
-                userRoomRepository.addUser(player, room);
+                                messageSender.sendPersonal(
+                                        getUserDestination(),
+                                        MessageType.GAME_SETTING,
+                                        gameSettingResponse,
+                                        principal.getName());
 
-                messageSender.sendPersonal(
-                    getUserDestination(),
-                    MessageType.GAME_SETTING,
-                    gameSettingResponse,
-                    principal.getName());
-
-                messageSender.sendBroadcast(destination, MessageType.ROOM_SETTING,
-                    roomSettingResponse);
-                messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST,
-                    playerListResponse);
-                messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE,
-                    systemNoticeResponse);
-            });
-        });
-
-
+                                messageSender.sendBroadcast(
+                                        destination, MessageType.ROOM_SETTING, roomSettingResponse);
+                                messageSender.sendBroadcast(
+                                        destination, MessageType.PLAYER_LIST, playerListResponse);
+                                messageSender.sendBroadcast(
+                                        destination,
+                                        MessageType.SYSTEM_NOTICE,
+                                        systemNoticeResponse);
+                            });
+                });
     }
 
     public void exitRoomWithLock(Long roomId, UserPrincipal principal) {
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, principal.getUserId(), () -> {
-            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
-                exitRoom(roomId, principal);
-            });
-        });
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                principal.getUserId(),
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                exitRoom(roomId, principal);
+                            });
+                });
     }
 
     private void exitRoom(Long roomId, UserPrincipal principal) {
@@ -242,34 +260,32 @@ public class RoomService {
         cleanRoom(room, removePlayer);
 
         messageSender.sendPersonal(
-            getUserDestination(),
-            MessageType.EXIT_SUCCESS,
-            new ExitSuccessResponse(true),
-            principal.getName());
+                getUserDestination(),
+                MessageType.EXIT_SUCCESS,
+                new ExitSuccessResponse(true),
+                principal.getName());
 
         SystemNoticeResponse systemNoticeResponse =
-            ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
+                ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
 
         PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
         messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
-        messageSender.sendBroadcast(
-            destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-
+        messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
     }
 
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
         List<RoomResponse> roomResponses =
-            rooms.stream()
-                .map(
-                    room -> {
-                        Long quizId = room.getGameSetting().getQuizId();
-                        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+                rooms.stream()
+                        .map(
+                                room -> {
+                                    Long quizId = room.getGameSetting().getQuizId();
+                                    Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                        return toRoomResponse(room, quiz);
-                    })
-                .toList();
+                                    return toRoomResponse(room, quiz);
+                                })
+                        .toList();
         return new RoomListResponse(roomResponses);
     }
 
@@ -285,27 +301,27 @@ public class RoomService {
         String userDestination = getUserDestination();
 
         messageSender.sendBroadcast(
-            destination,
-            MessageType.SYSTEM_NOTICE,
-            ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
+                destination,
+                MessageType.SYSTEM_NOTICE,
+                ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
 
         if (room.isPlaying()) {
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.SYSTEM_NOTICE,
-                ofPlayerEvent(
-                    principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
-                principal.getName());
+                    userDestination,
+                    MessageType.SYSTEM_NOTICE,
+                    ofPlayerEvent(
+                            principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.RANK_UPDATE,
-                toRankUpdateResponse(room),
-                principal.getName());
+                    userDestination,
+                    MessageType.RANK_UPDATE,
+                    toRankUpdateResponse(room),
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.GAME_START,
-                toGameStartResponse(room.getQuestions()),
-                principal.getName());
+                    userDestination,
+                    MessageType.GAME_START,
+                    toGameStartResponse(room.getQuestions()),
+                    principal.getName());
         } else {
             RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
 
@@ -314,25 +330,25 @@ public class RoomService {
             Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
             GameSettingResponse gameSettingResponse =
-                toGameSettingResponse(room.getGameSetting(), quiz);
+                    toGameSettingResponse(room.getGameSetting(), quiz);
 
             PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.ROOM_SETTING,
-                roomSettingResponse,
-                principal.getName());
+                    userDestination,
+                    MessageType.ROOM_SETTING,
+                    roomSettingResponse,
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.PLAYER_LIST,
-                playerListResponse,
-                principal.getName());
+                    userDestination,
+                    MessageType.PLAYER_LIST,
+                    playerListResponse,
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.GAME_SETTING,
-                gameSettingResponse,
-                principal.getName());
+                    userDestination,
+                    MessageType.GAME_SETTING,
+                    gameSettingResponse,
+                    principal.getName());
         }
     }
 
@@ -354,7 +370,7 @@ public class RoomService {
         Room room = findRoom(roomId);
         if (room.isPlaying()) {
             changeConnectedStatus(
-                room.getId(), principal.getUserId(), ConnectionState.DISCONNECTED);
+                    room.getId(), principal.getUserId(), ConnectionState.DISCONNECTED);
             removeUserRepository(principal.getUserId(), roomId);
         } else {
             exitRoom(room.getId(), principal);
@@ -371,8 +387,8 @@ public class RoomService {
 
     public Room findRoom(Long roomId) {
         return roomRepository
-            .findRoom(roomId)
-            .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
+                .findRoom(roomId)
+                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
     }
 
     private void removeRoom(Room room) {
@@ -385,36 +401,45 @@ public class RoomService {
         Map<Long, Player> playerMap = room.getPlayerMap();
 
         Optional<Player> nextHost =
-            playerMap.entrySet().stream()
-                .filter(entry -> !entry.getKey().equals(host.getId()))
-                .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
-                .map(Map.Entry::getValue)
-                .findFirst();
+                playerMap.entrySet().stream()
+                        .filter(entry -> !entry.getKey().equals(host.getId()))
+                        .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
+                        .map(Map.Entry::getValue)
+                        .findFirst();
 
         room.updateHost(
-            nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
+                nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
     }
 
     public void exitRoomForDisconnectedPlayer(Long roomId, Player player) {
         lockExecutor.executeWithLock(
-            USER_LOCK_PREFIX,player.getId(),()->{
-                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,()->{
-                    // 연결 끊긴 플레이어 exit 로직 타게 해주기
-                    Room room = findRoom(roomId);
+                USER_LOCK_PREFIX,
+                player.getId(),
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                // 연결 끊긴 플레이어 exit 로직 타게 해주기
+                                Room room = findRoom(roomId);
 
-                    cleanRoom(room, player);
+                                cleanRoom(room, player);
 
-                    String destination = getDestination(roomId);
+                                String destination = getDestination(roomId);
 
-                    SystemNoticeResponse systemNoticeResponse =
-                        ofPlayerEvent(player.nickname, RoomEventType.EXIT);
+                                SystemNoticeResponse systemNoticeResponse =
+                                        ofPlayerEvent(player.nickname, RoomEventType.EXIT);
 
-                    messageSender.sendBroadcast(
-                        destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-                    messageSender.sendBroadcast(
-                        destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                                messageSender.sendBroadcast(
+                                        destination,
+                                        MessageType.SYSTEM_NOTICE,
+                                        systemNoticeResponse);
+                                messageSender.sendBroadcast(
+                                        destination,
+                                        MessageType.PLAYER_LIST,
+                                        toPlayerListResponse(room));
+                            });
                 });
-            });
     }
 
     private void cleanRoom(Room room, Player player) {

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -67,6 +67,7 @@ public class RoomService {
     private final UserRoomRepository userRoomRepository;
     private final AtomicLong roomIdGenerator = new AtomicLong(0);
     private final ApplicationEventPublisher eventPublisher;
+    private final Map<String, Long> sessionRoomMap = new ConcurrentHashMap<>();
 
     private final DisconnectTaskManager disconnectTasks;
     private final MessageSender messageSender;
@@ -375,6 +376,11 @@ public class RoomService {
             .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
     }
 
+    public boolean existsRoom(Long roomId) {
+        return roomRepository
+            .findRoom(roomId).isPresent();
+    }
+
     private void removeRoom(Room room) {
         Long roomId = room.getId();
         roomRepository.removeRoom(roomId);
@@ -397,8 +403,8 @@ public class RoomService {
 
     public void exitRoomForDisconnectedPlayer(Long roomId, Player player) {
         lockExecutor.executeWithLock(
-            USER_LOCK_PREFIX,player.getId(),()->{
-                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,()->{
+            USER_LOCK_PREFIX, player.getId(), () -> {
+                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
                     // 연결 끊긴 플레이어 exit 로직 타게 해주기
                     Room room = findRoom(roomId);
 
@@ -461,7 +467,24 @@ public class RoomService {
         return userRoomRepository.isUserInAnyRoom(userId);
     }
 
-    public Long getRoomIdByUserId(Long userId) {
+    private Long getRoomIdByUserId(Long userId) {
         return userRoomRepository.getRoomId(userId);
+    }
+
+    @DistributedLock(prefix = "user", key = "#userId")
+    public Long getRoomIdByUserIdWithLock(Long userId) {
+        return userRoomRepository.getRoomId(userId);
+    }
+
+    public void addSessionRoomId(String sessionId, Long roomId) {
+        sessionRoomMap.put(sessionId, roomId);
+    }
+
+    public Long getRoomIdBySessionId(String sessionId) {
+        return sessionRoomMap.get(sessionId);
+    }
+
+    public void removeSessionRoomId(String sessionId) {
+        sessionRoomMap.remove(sessionId);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -47,15 +47,18 @@ import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 import io.f1.backend.global.lock.DistributedLock;
 import io.f1.backend.global.lock.LockExecutor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -75,7 +78,6 @@ public class RoomService {
 
     public static final String ROOM_LOCK_PREFIX = "room";
     public static final String USER_LOCK_PREFIX = "user";
-
 
     public RoomCreateResponse saveRoom(RoomCreateRequest request) {
 
@@ -98,8 +100,10 @@ public class RoomService {
         roomRepository.saveRoom(room);
 
         /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, host.getId(),
-            () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                host.getId(),
+                () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
         eventPublisher.publishEvent(new RoomCreatedEvent(room, quiz));
 
@@ -113,13 +117,14 @@ public class RoomService {
         Room room = findRoom(roomId);
 
         /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, getCurrentUserId(),
-            () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                getCurrentUserId(),
+                () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
-        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
-            () -> performEnterRoomLogic(request));
+        lockExecutor.executeWithLock(
+                ROOM_LOCK_PREFIX, roomId, () -> performEnterRoomLogic(request));
     }
-
 
     private void performEnterRoomLogic(RoomValidationRequest request) {
 
@@ -156,9 +161,10 @@ public class RoomService {
         Long joinedRoomId = getRoomIdByUserId(userId);
 
         if (joinedRoomId != null && !room.isSameRoom(joinedRoomId)) {
-            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, joinedRoomId,
-                () -> disconnectOrExitRoom(joinedRoomId, userPrincipal));
-
+            lockExecutor.executeWithLock(
+                    ROOM_LOCK_PREFIX,
+                    joinedRoomId,
+                    () -> disconnectOrExitRoom(joinedRoomId, userPrincipal));
         }
     }
 
@@ -166,66 +172,79 @@ public class RoomService {
 
         Long userId = principal.getUserId();
 
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId, () -> {
-            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                userId,
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                Room room = findRoom(roomId);
 
-                Room room = findRoom(roomId);
+                                if (!room.hasPlayer(userId)) {
+                                    throw new CustomException(RoomErrorCode.ROOM_ENTER_REQUIRED);
+                                }
 
-                if (!room.hasPlayer(userId)) {
-                    throw new CustomException(RoomErrorCode.ROOM_ENTER_REQUIRED);
-                }
+                                /* 재연결 */
+                                if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
+                                    changeConnectedStatus(
+                                            roomId, userId, ConnectionState.CONNECTED);
+                                    cancelTask(userId);
+                                    reconnectSendResponse(roomId, principal);
+                                    return;
+                                }
 
-                /* 재연결 */
-                if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
-                    changeConnectedStatus(roomId, userId, ConnectionState.CONNECTED);
-                    cancelTask(userId);
-                    reconnectSendResponse(roomId, principal);
-                    return;
-                }
+                                Player player = createPlayer(principal);
 
-                Player player = createPlayer(principal);
+                                RoomSettingResponse roomSettingResponse =
+                                        toRoomSettingResponse(room);
 
-                RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
+                                Long quizId = room.getGameSetting().getQuizId();
+                                Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                Long quizId = room.getGameSetting().getQuizId();
-                Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+                                GameSettingResponse gameSettingResponse =
+                                        toGameSettingResponse(room.getGameSetting(), quiz);
 
-                GameSettingResponse gameSettingResponse =
-                    toGameSettingResponse(room.getGameSetting(), quiz);
+                                PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
-                PlayerListResponse playerListResponse = toPlayerListResponse(room);
+                                SystemNoticeResponse systemNoticeResponse =
+                                        ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
 
-                SystemNoticeResponse systemNoticeResponse =
-                    ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
+                                String destination = getDestination(roomId);
 
-                String destination = getDestination(roomId);
+                                userRoomRepository.addUser(player, room);
 
-                userRoomRepository.addUser(player, room);
+                                messageSender.sendPersonal(
+                                        getUserDestination(),
+                                        MessageType.GAME_SETTING,
+                                        gameSettingResponse,
+                                        principal.getName());
 
-                messageSender.sendPersonal(
-                    getUserDestination(),
-                    MessageType.GAME_SETTING,
-                    gameSettingResponse,
-                    principal.getName());
-
-                messageSender.sendBroadcast(destination, MessageType.ROOM_SETTING,
-                    roomSettingResponse);
-                messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST,
-                    playerListResponse);
-                messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE,
-                    systemNoticeResponse);
-            });
-        });
-
-
+                                messageSender.sendBroadcast(
+                                        destination, MessageType.ROOM_SETTING, roomSettingResponse);
+                                messageSender.sendBroadcast(
+                                        destination, MessageType.PLAYER_LIST, playerListResponse);
+                                messageSender.sendBroadcast(
+                                        destination,
+                                        MessageType.SYSTEM_NOTICE,
+                                        systemNoticeResponse);
+                            });
+                });
     }
 
     public void exitRoomWithLock(Long roomId, UserPrincipal principal) {
-        lockExecutor.executeWithLock(USER_LOCK_PREFIX, principal.getUserId(), () -> {
-            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
-                exitRoom(roomId, principal);
-            });
-        });
+        lockExecutor.executeWithLock(
+                USER_LOCK_PREFIX,
+                principal.getUserId(),
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                exitRoom(roomId, principal);
+                            });
+                });
     }
 
     private void exitRoom(Long roomId, UserPrincipal principal) {
@@ -243,34 +262,32 @@ public class RoomService {
         cleanRoom(room, removePlayer);
 
         messageSender.sendPersonal(
-            getUserDestination(),
-            MessageType.EXIT_SUCCESS,
-            new ExitSuccessResponse(true),
-            principal.getName());
+                getUserDestination(),
+                MessageType.EXIT_SUCCESS,
+                new ExitSuccessResponse(true),
+                principal.getName());
 
         SystemNoticeResponse systemNoticeResponse =
-            ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
+                ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
 
         PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
         messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
-        messageSender.sendBroadcast(
-            destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-
+        messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
     }
 
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
         List<RoomResponse> roomResponses =
-            rooms.stream()
-                .map(
-                    room -> {
-                        Long quizId = room.getGameSetting().getQuizId();
-                        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+                rooms.stream()
+                        .map(
+                                room -> {
+                                    Long quizId = room.getGameSetting().getQuizId();
+                                    Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                        return toRoomResponse(room, quiz);
-                    })
-                .toList();
+                                    return toRoomResponse(room, quiz);
+                                })
+                        .toList();
         return new RoomListResponse(roomResponses);
     }
 
@@ -286,27 +303,27 @@ public class RoomService {
         String userDestination = getUserDestination();
 
         messageSender.sendBroadcast(
-            destination,
-            MessageType.SYSTEM_NOTICE,
-            ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
+                destination,
+                MessageType.SYSTEM_NOTICE,
+                ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
 
         if (room.isPlaying()) {
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.SYSTEM_NOTICE,
-                ofPlayerEvent(
-                    principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
-                principal.getName());
+                    userDestination,
+                    MessageType.SYSTEM_NOTICE,
+                    ofPlayerEvent(
+                            principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.RANK_UPDATE,
-                toRankUpdateResponse(room),
-                principal.getName());
+                    userDestination,
+                    MessageType.RANK_UPDATE,
+                    toRankUpdateResponse(room),
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.GAME_START,
-                toGameStartResponse(room.getQuestions()),
-                principal.getName());
+                    userDestination,
+                    MessageType.GAME_START,
+                    toGameStartResponse(room.getQuestions()),
+                    principal.getName());
         } else {
             RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
 
@@ -315,25 +332,25 @@ public class RoomService {
             Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
             GameSettingResponse gameSettingResponse =
-                toGameSettingResponse(room.getGameSetting(), quiz);
+                    toGameSettingResponse(room.getGameSetting(), quiz);
 
             PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.ROOM_SETTING,
-                roomSettingResponse,
-                principal.getName());
+                    userDestination,
+                    MessageType.ROOM_SETTING,
+                    roomSettingResponse,
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.PLAYER_LIST,
-                playerListResponse,
-                principal.getName());
+                    userDestination,
+                    MessageType.PLAYER_LIST,
+                    playerListResponse,
+                    principal.getName());
             messageSender.sendPersonal(
-                userDestination,
-                MessageType.GAME_SETTING,
-                gameSettingResponse,
-                principal.getName());
+                    userDestination,
+                    MessageType.GAME_SETTING,
+                    gameSettingResponse,
+                    principal.getName());
         }
     }
 
@@ -355,7 +372,7 @@ public class RoomService {
         Room room = findRoom(roomId);
         if (room.isPlaying()) {
             changeConnectedStatus(
-                room.getId(), principal.getUserId(), ConnectionState.DISCONNECTED);
+                    room.getId(), principal.getUserId(), ConnectionState.DISCONNECTED);
             removeUserRepository(principal.getUserId(), roomId);
         } else {
             exitRoom(room.getId(), principal);
@@ -372,13 +389,12 @@ public class RoomService {
 
     public Room findRoom(Long roomId) {
         return roomRepository
-            .findRoom(roomId)
-            .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
+                .findRoom(roomId)
+                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
     }
 
     public boolean existsRoom(Long roomId) {
-        return roomRepository
-            .findRoom(roomId).isPresent();
+        return roomRepository.findRoom(roomId).isPresent();
     }
 
     private void removeRoom(Room room) {
@@ -391,36 +407,45 @@ public class RoomService {
         Map<Long, Player> playerMap = room.getPlayerMap();
 
         Optional<Player> nextHost =
-            playerMap.entrySet().stream()
-                .filter(entry -> !entry.getKey().equals(host.getId()))
-                .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
-                .map(Map.Entry::getValue)
-                .findFirst();
+                playerMap.entrySet().stream()
+                        .filter(entry -> !entry.getKey().equals(host.getId()))
+                        .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
+                        .map(Map.Entry::getValue)
+                        .findFirst();
 
         room.updateHost(
-            nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
+                nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
     }
 
     public void exitRoomForDisconnectedPlayer(Long roomId, Player player) {
         lockExecutor.executeWithLock(
-            USER_LOCK_PREFIX,player.getId(),()->{
-                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,()->{
-                    // 연결 끊긴 플레이어 exit 로직 타게 해주기
-                    Room room = findRoom(roomId);
+                USER_LOCK_PREFIX,
+                player.getId(),
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                // 연결 끊긴 플레이어 exit 로직 타게 해주기
+                                Room room = findRoom(roomId);
 
-                    cleanRoom(room, player);
+                                cleanRoom(room, player);
 
-                    String destination = getDestination(roomId);
+                                String destination = getDestination(roomId);
 
-                    SystemNoticeResponse systemNoticeResponse =
-                        ofPlayerEvent(player.nickname, RoomEventType.EXIT);
+                                SystemNoticeResponse systemNoticeResponse =
+                                        ofPlayerEvent(player.nickname, RoomEventType.EXIT);
 
-                    messageSender.sendBroadcast(
-                        destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-                    messageSender.sendBroadcast(
-                        destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                                messageSender.sendBroadcast(
+                                        destination,
+                                        MessageType.SYSTEM_NOTICE,
+                                        systemNoticeResponse);
+                                messageSender.sendBroadcast(
+                                        destination,
+                                        MessageType.PLAYER_LIST,
+                                        toPlayerListResponse(room));
+                            });
                 });
-            });
     }
 
     private void cleanRoom(Room room, Player player) {

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -9,6 +9,7 @@ import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomResponse;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSetting;
 import static io.f1.backend.domain.game.mapper.RoomMapper.toRoomSettingResponse;
 import static io.f1.backend.domain.game.websocket.WebSocketUtils.getDestination;
+import static io.f1.backend.domain.game.websocket.WebSocketUtils.getUserDestination;
 import static io.f1.backend.domain.quiz.mapper.QuizMapper.toGameStartResponse;
 import static io.f1.backend.global.security.util.SecurityUtils.getCurrentUserId;
 import static io.f1.backend.global.security.util.SecurityUtils.getCurrentUserNickname;
@@ -44,18 +45,17 @@ import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
+import io.f1.backend.global.lock.DistributedLock;
+import io.f1.backend.global.lock.LockExecutor;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -67,10 +67,14 @@ public class RoomService {
     private final UserRoomRepository userRoomRepository;
     private final AtomicLong roomIdGenerator = new AtomicLong(0);
     private final ApplicationEventPublisher eventPublisher;
-    private final Map<Long, Object> roomLocks = new ConcurrentHashMap<>();
-    private final DisconnectTaskManager disconnectTasks;
 
+    private final DisconnectTaskManager disconnectTasks;
     private final MessageSender messageSender;
+    private final LockExecutor lockExecutor;
+
+    public static final String ROOM_LOCK_PREFIX = "room";
+    public static final String USER_LOCK_PREFIX = "user";
+
 
     public RoomCreateResponse saveRoom(RoomCreateRequest request) {
 
@@ -93,7 +97,8 @@ public class RoomService {
         roomRepository.saveRoom(room);
 
         /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-        exitIfInAnotherRoom(room, getCurrentUserPrincipal());
+        lockExecutor.executeWithLock(USER_LOCK_PREFIX, host.getId(),
+            () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
         eventPublisher.publishEvent(new RoomCreatedEvent(room, quiz));
 
@@ -104,37 +109,45 @@ public class RoomService {
 
         Long roomId = request.roomId();
 
-        Object lock = roomLocks.computeIfAbsent(roomId, k -> new Object());
+        Room room = findRoom(roomId);
 
-        synchronized (lock) {
-            Room room = findRoom(request.roomId());
+        /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
+        lockExecutor.executeWithLock(USER_LOCK_PREFIX, getCurrentUserId(),
+            () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
-            Long userId = getCurrentUserId();
+        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
+            () -> performEnterRoomLogic(request));
+    }
 
-            /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-            exitIfInAnotherRoom(room, getCurrentUserPrincipal());
 
-            /* reconnect */
-            if (room.hasPlayer(userId)) {
-                return;
-            }
+    private void performEnterRoomLogic(RoomValidationRequest request) {
 
-            if (room.isPlaying()) {
-                throw new CustomException(RoomErrorCode.ROOM_GAME_IN_PROGRESS);
-            }
+        Long roomId = request.roomId();
 
-            int maxUserCnt = room.getRoomSetting().maxUserCount();
-            int currentCnt = room.getCurrentUserCnt();
-            if (maxUserCnt == currentCnt) {
-                throw new CustomException(RoomErrorCode.ROOM_USER_LIMIT_REACHED);
-            }
+        Room room = findRoom(roomId);
 
-            if (room.isPasswordIncorrect(request.password())) {
-                throw new CustomException(RoomErrorCode.WRONG_PASSWORD);
-            }
+        Long userId = getCurrentUserId();
 
-            room.addPlayer(createPlayer());
+        /* reconnect */
+        if (room.hasPlayer(userId)) {
+            return;
         }
+
+        if (room.isPlaying()) {
+            throw new CustomException(RoomErrorCode.ROOM_GAME_IN_PROGRESS);
+        }
+
+        int maxUserCnt = room.getRoomSetting().maxUserCount();
+        int currentCnt = room.getCurrentUserCnt();
+        if (maxUserCnt == currentCnt) {
+            throw new CustomException(RoomErrorCode.ROOM_USER_LIMIT_REACHED);
+        }
+
+        if (room.isPasswordIncorrect(request.password())) {
+            throw new CustomException(RoomErrorCode.WRONG_PASSWORD);
+        }
+
+        room.addPlayer(createPlayer());
     }
 
     private void exitIfInAnotherRoom(Room room, UserPrincipal userPrincipal) {
@@ -142,104 +155,127 @@ public class RoomService {
         Long joinedRoomId = getRoomIdByUserId(userId);
 
         if (joinedRoomId != null && !room.isSameRoom(joinedRoomId)) {
-            disconnectOrExitRoom(joinedRoomId, userPrincipal);
+            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, joinedRoomId,
+                () -> disconnectOrExitRoom(joinedRoomId, userPrincipal));
+
         }
     }
 
     public void initializeRoomSocket(Long roomId, UserPrincipal principal) {
 
-        Room room = findRoom(roomId);
         Long userId = principal.getUserId();
 
-        if (!room.hasPlayer(userId)) {
-            throw new CustomException(RoomErrorCode.ROOM_ENTER_REQUIRED);
+        lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId, () -> {
+            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
+
+                Room room = findRoom(roomId);
+
+                if (!room.hasPlayer(userId)) {
+                    throw new CustomException(RoomErrorCode.ROOM_ENTER_REQUIRED);
+                }
+
+                /* 재연결 */
+                if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
+                    changeConnectedStatus(roomId, userId, ConnectionState.CONNECTED);
+                    cancelTask(userId);
+                    reconnectSendResponse(roomId, principal);
+                    return;
+                }
+
+                Player player = createPlayer(principal);
+
+                RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
+
+                Long quizId = room.getGameSetting().getQuizId();
+                Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+
+                GameSettingResponse gameSettingResponse =
+                    toGameSettingResponse(room.getGameSetting(), quiz);
+
+                PlayerListResponse playerListResponse = toPlayerListResponse(room);
+
+                SystemNoticeResponse systemNoticeResponse =
+                    ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
+
+                String destination = getDestination(roomId);
+
+                userRoomRepository.addUser(player, room);
+
+                messageSender.sendPersonal(
+                    getUserDestination(),
+                    MessageType.GAME_SETTING,
+                    gameSettingResponse,
+                    principal.getName());
+
+                messageSender.sendBroadcast(destination, MessageType.ROOM_SETTING,
+                    roomSettingResponse);
+                messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST,
+                    playerListResponse);
+                messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE,
+                    systemNoticeResponse);
+            });
+        });
+
+
+    }
+
+    public void exitRoomWithLock(Long roomId, UserPrincipal principal) {
+        lockExecutor.executeWithLock(USER_LOCK_PREFIX, principal.getUserId(), () -> {
+            lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId, () -> {
+                exitRoom(roomId, principal);
+            });
+        });
+    }
+
+    private void exitRoom(Long roomId, UserPrincipal principal) {
+
+        Room room = findRoom(roomId);
+
+        if (!room.hasPlayer(principal.getUserId())) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
         }
 
-        /* 재연결 */
-        if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
-            changeConnectedStatus(roomId, userId, ConnectionState.CONNECTED);
-            cancelTask(userId);
-            reconnectSendResponse(roomId, principal);
-            return;
-        }
-
-        Player player = createPlayer(principal);
-
-        RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
-
-        Long quizId = room.getGameSetting().getQuizId();
-        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
-
-        GameSettingResponse gameSettingResponse =
-                toGameSettingResponse(room.getGameSetting(), quiz);
-
-        PlayerListResponse playerListResponse = toPlayerListResponse(room);
-
-        SystemNoticeResponse systemNoticeResponse =
-                ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
+        Player removePlayer = createPlayer(principal);
 
         String destination = getDestination(roomId);
 
-        userRoomRepository.addUser(player, room);
+        cleanRoom(room, removePlayer);
 
         messageSender.sendPersonal(
-                getUserDestination(),
-                MessageType.GAME_SETTING,
-                gameSettingResponse,
-                principal.getName());
+            getUserDestination(),
+            MessageType.EXIT_SUCCESS,
+            new ExitSuccessResponse(true),
+            principal.getName());
 
-        messageSender.sendBroadcast(destination, MessageType.ROOM_SETTING, roomSettingResponse);
+        SystemNoticeResponse systemNoticeResponse =
+            ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
+
+        PlayerListResponse playerListResponse = toPlayerListResponse(room);
+
         messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
-        messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-    }
+        messageSender.sendBroadcast(
+            destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
 
-    public void exitRoom(Long roomId, UserPrincipal principal) {
-
-        Object lock = roomLocks.computeIfAbsent(roomId, k -> new Object());
-
-        synchronized (lock) {
-            Room room = findRoom(roomId);
-
-            if (!room.hasPlayer(principal.getUserId())) {
-                throw new CustomException(UserErrorCode.USER_NOT_FOUND);
-            }
-
-            Player removePlayer = createPlayer(principal);
-
-            String destination = getDestination(roomId);
-
-            cleanRoom(room, removePlayer);
-
-            messageSender.sendPersonal(
-                    getUserDestination(),
-                    MessageType.EXIT_SUCCESS,
-                    new ExitSuccessResponse(true),
-                    principal.getName());
-
-            SystemNoticeResponse systemNoticeResponse =
-                    ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
-
-            PlayerListResponse playerListResponse = toPlayerListResponse(room);
-
-            messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
-            messageSender.sendBroadcast(
-                    destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-        }
     }
 
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
         List<RoomResponse> roomResponses =
-                rooms.stream()
-                        .map(
-                                room -> {
-                                    Long quizId = room.getGameSetting().getQuizId();
-                                    Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+            rooms.stream()
+                .map(
+                    room -> {
+                        Long quizId = room.getGameSetting().getQuizId();
+                        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                                    return toRoomResponse(room, quiz);
-                                })
-                        .toList();
+                        return toRoomResponse(room, quiz);
+                    })
+                .toList();
         return new RoomListResponse(roomResponses);
+    }
+
+    @DistributedLock(prefix = "room", key = "#roomId")
+    public void reconnectSendResponseWithLock(Long roomId, UserPrincipal principal) {
+        reconnectSendResponse(roomId, principal);
     }
 
     public void reconnectSendResponse(Long roomId, UserPrincipal principal) {
@@ -249,27 +285,27 @@ public class RoomService {
         String userDestination = getUserDestination();
 
         messageSender.sendBroadcast(
-                destination,
-                MessageType.SYSTEM_NOTICE,
-                ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
+            destination,
+            MessageType.SYSTEM_NOTICE,
+            ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
 
         if (room.isPlaying()) {
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.SYSTEM_NOTICE,
-                    ofPlayerEvent(
-                            principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
-                    principal.getName());
+                userDestination,
+                MessageType.SYSTEM_NOTICE,
+                ofPlayerEvent(
+                    principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
+                principal.getName());
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.RANK_UPDATE,
-                    toRankUpdateResponse(room),
-                    principal.getName());
+                userDestination,
+                MessageType.RANK_UPDATE,
+                toRankUpdateResponse(room),
+                principal.getName());
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.GAME_START,
-                    toGameStartResponse(room.getQuestions()),
-                    principal.getName());
+                userDestination,
+                MessageType.GAME_START,
+                toGameStartResponse(room.getQuestions()),
+                principal.getName());
         } else {
             RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
 
@@ -278,26 +314,31 @@ public class RoomService {
             Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
             GameSettingResponse gameSettingResponse =
-                    toGameSettingResponse(room.getGameSetting(), quiz);
+                toGameSettingResponse(room.getGameSetting(), quiz);
 
             PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.ROOM_SETTING,
-                    roomSettingResponse,
-                    principal.getName());
+                userDestination,
+                MessageType.ROOM_SETTING,
+                roomSettingResponse,
+                principal.getName());
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.PLAYER_LIST,
-                    playerListResponse,
-                    principal.getName());
+                userDestination,
+                MessageType.PLAYER_LIST,
+                playerListResponse,
+                principal.getName());
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.GAME_SETTING,
-                    gameSettingResponse,
-                    principal.getName());
+                userDestination,
+                MessageType.GAME_SETTING,
+                gameSettingResponse,
+                principal.getName());
         }
+    }
+
+    @DistributedLock(prefix = "room", key = "#roomId")
+    public void changeConnectedStatusWithLock(Long roomId, Long userId, ConnectionState newState) {
+        changeConnectedStatus(roomId, userId, newState);
     }
 
     public void changeConnectedStatus(Long roomId, Long userId, ConnectionState newState) {
@@ -313,7 +354,7 @@ public class RoomService {
         Room room = findRoom(roomId);
         if (room.isPlaying()) {
             changeConnectedStatus(
-                    room.getId(), principal.getUserId(), ConnectionState.DISCONNECTED);
+                room.getId(), principal.getUserId(), ConnectionState.DISCONNECTED);
             removeUserRepository(principal.getUserId(), roomId);
         } else {
             exitRoom(room.getId(), principal);
@@ -330,14 +371,13 @@ public class RoomService {
 
     public Room findRoom(Long roomId) {
         return roomRepository
-                .findRoom(roomId)
-                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
+            .findRoom(roomId)
+            .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
     }
 
     private void removeRoom(Room room) {
         Long roomId = room.getId();
         roomRepository.removeRoom(roomId);
-        roomLocks.remove(roomId);
         log.info("{}번 방 삭제", roomId);
     }
 
@@ -345,36 +385,36 @@ public class RoomService {
         Map<Long, Player> playerMap = room.getPlayerMap();
 
         Optional<Player> nextHost =
-                playerMap.entrySet().stream()
-                        .filter(entry -> !entry.getKey().equals(host.getId()))
-                        .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
-                        .map(Map.Entry::getValue)
-                        .findFirst();
+            playerMap.entrySet().stream()
+                .filter(entry -> !entry.getKey().equals(host.getId()))
+                .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
+                .map(Map.Entry::getValue)
+                .findFirst();
 
         room.updateHost(
-                nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
+            nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
     }
 
     public void exitRoomForDisconnectedPlayer(Long roomId, Player player) {
+        lockExecutor.executeWithLock(
+            USER_LOCK_PREFIX,player.getId(),()->{
+                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,()->{
+                    // 연결 끊긴 플레이어 exit 로직 타게 해주기
+                    Room room = findRoom(roomId);
 
-        Object lock = roomLocks.computeIfAbsent(roomId, k -> new Object());
+                    cleanRoom(room, player);
 
-        synchronized (lock) {
-            // 연결 끊긴 플레이어 exit 로직 타게 해주기
-            Room room = findRoom(roomId);
+                    String destination = getDestination(roomId);
 
-            cleanRoom(room, player);
+                    SystemNoticeResponse systemNoticeResponse =
+                        ofPlayerEvent(player.nickname, RoomEventType.EXIT);
 
-            String destination = getDestination(roomId);
-
-            SystemNoticeResponse systemNoticeResponse =
-                    ofPlayerEvent(player.nickname, RoomEventType.EXIT);
-
-            messageSender.sendBroadcast(
-                    destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-            messageSender.sendBroadcast(
-                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
-        }
+                    messageSender.sendBroadcast(
+                        destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
+                    messageSender.sendBroadcast(
+                        destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
+                });
+            });
     }
 
     private void cleanRoom(Room room, Player player) {
@@ -416,6 +456,7 @@ public class RoomService {
         userRoomRepository.removeUser(userId, roomId);
     }
 
+    @DistributedLock(prefix = "user", key = "#userId")
     public boolean isUserInAnyRoom(Long userId) {
         return userRoomRepository.isUserInAnyRoom(userId);
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -45,6 +45,7 @@ import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 
+import io.f1.backend.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -100,50 +101,50 @@ public class RoomService {
         return new RoomCreateResponse(newId);
     }
 
+    @DistributedLock(prefix = "room", key = "#roomId")
     public void enterRoom(RoomValidationRequest request) {
 
         Long roomId = request.roomId();
 
-        Object lock = roomLocks.computeIfAbsent(roomId, k -> new Object());
+        Room room = findRoom(roomId);
 
-        synchronized (lock) {
-            Room room = findRoom(request.roomId());
+        Long userId = getCurrentUserId();
 
-            Long userId = getCurrentUserId();
+        /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
+        exitIfInAnotherRoom(room, userId);
 
-            /* 다른 방 접속 시 기존 방은 exit 처리 - 탭 동시 로그인 시 (disconnected 리스너 작동x)  */
-            exitIfInAnotherRoom(room, userId);
-
-            /* reconnect */
-            if (room.hasPlayer(userId)) {
-                return;
-            }
-
-            if (room.isPlaying()) {
-                throw new CustomException(RoomErrorCode.ROOM_GAME_IN_PROGRESS);
-            }
-
-            int maxUserCnt = room.getRoomSetting().maxUserCount();
-            int currentCnt = room.getCurrentUserCnt();
-            if (maxUserCnt == currentCnt) {
-                throw new CustomException(RoomErrorCode.ROOM_USER_LIMIT_REACHED);
-            }
-
-            if (room.isPasswordIncorrect(request.password())) {
-                throw new CustomException(RoomErrorCode.WRONG_PASSWORD);
-            }
-
-            room.addPlayer(createPlayer());
+        /* reconnect */
+        if (room.hasPlayer(userId)) {
+            return;
         }
+
+        if (room.isPlaying()) {
+            throw new CustomException(RoomErrorCode.ROOM_GAME_IN_PROGRESS);
+        }
+
+        int maxUserCnt = room.getRoomSetting().maxUserCount();
+        int currentCnt = room.getCurrentUserCnt();
+        if (maxUserCnt == currentCnt) {
+            throw new CustomException(RoomErrorCode.ROOM_USER_LIMIT_REACHED);
+        }
+
+        if (room.isPasswordIncorrect(request.password())) {
+            throw new CustomException(RoomErrorCode.WRONG_PASSWORD);
+        }
+
+        room.addPlayer(createPlayer());
+
     }
 
     private void exitIfInAnotherRoom(Room room, Long userId) {
-
         Long joinedRoomId = userRoomRepository.getRoomId(userId);
 
         if (joinedRoomId != null && !room.isSameRoom(joinedRoomId)) {
-            if (room.isPlaying()) {
-                changeConnectedStatus(userId, ConnectionState.DISCONNECTED);
+
+            Room joinedRoom = findRoom(joinedRoomId);
+
+            if (joinedRoom.isPlaying()) {
+                changeConnectedStatus(userId, joinedRoomId, ConnectionState.DISCONNECTED);
             } else {
                 exitRoom(joinedRoomId, getCurrentUserPrincipal());
             }
@@ -161,7 +162,7 @@ public class RoomService {
 
         /* 재연결 */
         if (room.isPlayerInState(userId, ConnectionState.DISCONNECTED)) {
-            changeConnectedStatus(userId, ConnectionState.CONNECTED);
+            changeConnectedStatus(userId, roomId, ConnectionState.CONNECTED);
             cancelTask(userId);
             reconnectSendResponse(roomId, principal);
             return;
@@ -175,71 +176,69 @@ public class RoomService {
         Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
         GameSettingResponse gameSettingResponse =
-                toGameSettingResponse(room.getGameSetting(), quiz);
+            toGameSettingResponse(room.getGameSetting(), quiz);
 
         PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
         SystemNoticeResponse systemNoticeResponse =
-                ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
+            ofPlayerEvent(player.getNickname(), RoomEventType.ENTER);
 
         String destination = getDestination(roomId);
 
         userRoomRepository.addUser(player, room);
 
         messageSender.sendPersonal(
-                getUserDestination(), MessageType.GAME_SETTING, gameSettingResponse, principal);
+            getUserDestination(), MessageType.GAME_SETTING, gameSettingResponse, principal);
 
         messageSender.sendBroadcast(destination, MessageType.ROOM_SETTING, roomSettingResponse);
         messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
         messageSender.sendBroadcast(destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
     }
 
+    @DistributedLock(prefix = "room", key = "#roomId")
     public void exitRoom(Long roomId, UserPrincipal principal) {
 
-        Object lock = roomLocks.computeIfAbsent(roomId, k -> new Object());
+        Room room = findRoom(roomId);
 
-        synchronized (lock) {
-            Room room = findRoom(roomId);
-
-            if (!room.hasPlayer(principal.getUserId())) {
-                throw new CustomException(UserErrorCode.USER_NOT_FOUND);
-            }
-
-            Player removePlayer = createPlayer(principal);
-
-            String destination = getDestination(roomId);
-
-            cleanRoom(room, removePlayer);
-
-            messageSender.sendPersonal(
-                    getUserDestination(),
-                    MessageType.EXIT_SUCCESS,
-                    new ExitSuccessResponse(true),
-                    principal);
-
-            SystemNoticeResponse systemNoticeResponse =
-                    ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
-
-            PlayerListResponse playerListResponse = toPlayerListResponse(room);
-
-            messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
-            messageSender.sendBroadcast(
-                    destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
+        if (!room.hasPlayer(principal.getUserId())) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
         }
+
+        Player removePlayer = createPlayer(principal);
+
+        String destination = getDestination(roomId);
+
+        cleanRoom(room, removePlayer);
+
+        messageSender.sendPersonal(
+            getUserDestination(),
+            MessageType.EXIT_SUCCESS,
+            new ExitSuccessResponse(true),
+            principal);
+
+        SystemNoticeResponse systemNoticeResponse =
+            ofPlayerEvent(removePlayer.nickname, RoomEventType.EXIT);
+
+        PlayerListResponse playerListResponse = toPlayerListResponse(room);
+
+        messageSender.sendBroadcast(destination, MessageType.PLAYER_LIST, playerListResponse);
+        messageSender.sendBroadcast(
+            destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
+
     }
 
     public RoomListResponse getAllRooms() {
         List<Room> rooms = roomRepository.findAll();
         List<RoomResponse> roomResponses =
-                rooms.stream()
-                        .map(
-                                room -> {
-                                    Long quizId = room.getGameSetting().getQuizId();
-                                    Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+            rooms.stream()
+                .map(
+                    room -> {
+                        Long quizId = room.getGameSetting().getQuizId();
+                        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
-                                    return toRoomResponse(room, quiz);
-                                })
-                        .toList();
+                        return toRoomResponse(room, quiz);
+                    })
+                .toList();
         return new RoomListResponse(roomResponses);
     }
 
@@ -250,27 +249,27 @@ public class RoomService {
         String userDestination = getUserDestination();
 
         messageSender.sendBroadcast(
-                destination,
-                MessageType.SYSTEM_NOTICE,
-                ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
+            destination,
+            MessageType.SYSTEM_NOTICE,
+            ofPlayerEvent(principal.getUserNickname(), RoomEventType.RECONNECT));
 
         if (room.isPlaying()) {
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.SYSTEM_NOTICE,
-                    ofPlayerEvent(
-                            principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
-                    principal);
+                userDestination,
+                MessageType.SYSTEM_NOTICE,
+                ofPlayerEvent(
+                    principal.getUserNickname(), RoomEventType.RECONNECT_PRIVATE_NOTICE),
+                principal);
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.RANK_UPDATE,
-                    toRankUpdateResponse(room),
-                    principal);
+                userDestination,
+                MessageType.RANK_UPDATE,
+                toRankUpdateResponse(room),
+                principal);
             messageSender.sendPersonal(
-                    userDestination,
-                    MessageType.GAME_START,
-                    toGameStartResponse(room.getQuestions()),
-                    principal);
+                userDestination,
+                MessageType.GAME_START,
+                toGameStartResponse(room.getQuestions()),
+                principal);
         } else {
             RoomSettingResponse roomSettingResponse = toRoomSettingResponse(room);
 
@@ -279,26 +278,26 @@ public class RoomService {
             Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
             GameSettingResponse gameSettingResponse =
-                    toGameSettingResponse(room.getGameSetting(), quiz);
+                toGameSettingResponse(room.getGameSetting(), quiz);
 
             PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
             messageSender.sendPersonal(
-                    userDestination, MessageType.ROOM_SETTING, roomSettingResponse, principal);
+                userDestination, MessageType.ROOM_SETTING, roomSettingResponse, principal);
             messageSender.sendPersonal(
-                    userDestination, MessageType.PLAYER_LIST, playerListResponse, principal);
+                userDestination, MessageType.PLAYER_LIST, playerListResponse, principal);
             messageSender.sendPersonal(
-                    userDestination, MessageType.GAME_SETTING, gameSettingResponse, principal);
+                userDestination, MessageType.GAME_SETTING, gameSettingResponse, principal);
         }
     }
 
-    public Long changeConnectedStatus(Long userId, ConnectionState newState) {
-        Long roomId = userRoomRepository.getRoomId(userId);
+    public void changeConnectedStatus(Long userId, Long roomId, ConnectionState newState) {
         Room room = findRoom(roomId);
-
         room.updatePlayerConnectionState(userId, newState);
+    }
 
-        return roomId;
+    public Long getUserRoomId(Long userId) {
+        return userRoomRepository.getRoomId(userId);
     }
 
     public void cancelTask(Long userId) {
@@ -324,8 +323,8 @@ public class RoomService {
 
     public Room findRoom(Long roomId) {
         return roomRepository
-                .findRoom(roomId)
-                .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
+            .findRoom(roomId)
+            .orElseThrow(() -> new CustomException(RoomErrorCode.ROOM_NOT_FOUND));
     }
 
     private void removeRoom(Room room) {
@@ -339,40 +338,38 @@ public class RoomService {
         Map<Long, Player> playerMap = room.getPlayerMap();
 
         Optional<Player> nextHost =
-                playerMap.entrySet().stream()
-                        .filter(entry -> !entry.getKey().equals(host.getId()))
-                        .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
-                        .map(Map.Entry::getValue)
-                        .findFirst();
+            playerMap.entrySet().stream()
+                .filter(entry -> !entry.getKey().equals(host.getId()))
+                .filter(entry -> entry.getValue().getState() == ConnectionState.CONNECTED)
+                .map(Map.Entry::getValue)
+                .findFirst();
 
         room.updateHost(
-                nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
+            nextHost.orElseThrow(() -> new CustomException(RoomErrorCode.PLAYER_NOT_FOUND)));
     }
 
     private String getUserDestination() {
         return "/queue";
     }
 
+    @DistributedLock(prefix = "room", key = "#roomId")
     public void exitRoomForDisconnectedPlayer(Long roomId, Player player) {
 
-        Object lock = roomLocks.computeIfAbsent(roomId, k -> new Object());
+        // 연결 끊긴 플레이어 exit 로직 타게 해주기
+        Room room = findRoom(roomId);
 
-        synchronized (lock) {
-            // 연결 끊긴 플레이어 exit 로직 타게 해주기
-            Room room = findRoom(roomId);
+        cleanRoom(room, player);
 
-            cleanRoom(room, player);
+        String destination = getDestination(roomId);
 
-            String destination = getDestination(roomId);
+        SystemNoticeResponse systemNoticeResponse =
+            ofPlayerEvent(player.nickname, RoomEventType.EXIT);
 
-            SystemNoticeResponse systemNoticeResponse =
-                    ofPlayerEvent(player.nickname, RoomEventType.EXIT);
+        messageSender.sendBroadcast(
+            destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
+        messageSender.sendBroadcast(
+            destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
 
-            messageSender.sendBroadcast(
-                    destination, MessageType.SYSTEM_NOTICE, systemNoticeResponse);
-            messageSender.sendBroadcast(
-                    destination, MessageType.PLAYER_LIST, toPlayerListResponse(room));
-        }
     }
 
     private void cleanRoom(Room room, Player player) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -9,10 +9,10 @@ import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.HeartbeatResponse;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.lock.LockExecutor;
-
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpUser;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
@@ -20,11 +20,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
-import java.security.Principal;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class HeartbeatMonitor {
@@ -69,7 +65,6 @@ public class HeartbeatMonitor {
         int missedCnt = missedPongCounter.get(sessionId);
 
         /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
-        log.info("missedCnt = {}", missedCnt);
         if (missedCnt >= MAX_MISSED_HEARTBEATS) {
 
             Principal principal = user.getPrincipal();

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -9,10 +9,9 @@ import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.HeartbeatResponse;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.lock.LockExecutor;
-import java.security.Principal;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpUser;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
@@ -20,6 +19,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 @RequiredArgsConstructor

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -1,22 +1,25 @@
 package io.f1.backend.domain.game.websocket;
 
+import static io.f1.backend.domain.game.app.RoomService.ROOM_LOCK_PREFIX;
+import static io.f1.backend.domain.game.app.RoomService.USER_LOCK_PREFIX;
 import static io.f1.backend.domain.game.websocket.WebSocketUtils.getUserDestination;
 
 import io.f1.backend.domain.game.app.RoomService;
 import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.HeartbeatResponse;
-
+import io.f1.backend.domain.user.dto.UserPrincipal;
+import io.f1.backend.global.lock.LockExecutor;
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpUser;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component
@@ -32,6 +35,7 @@ public class HeartbeatMonitor {
     private final MessageSender messageSender;
     private final RoomService roomService;
     private final SimpUserRegistry simpUserRegistry;
+    private final LockExecutor lockExecutor;
 
     @Scheduled(fixedDelay = HEARTBEAT_CHECK_INTERVAL_MS)
     public void monitorClientHeartbeat() {
@@ -41,11 +45,11 @@ public class HeartbeatMonitor {
         }
 
         simpUserRegistry
-                .getUsers()
-                .forEach(
-                        user ->
-                                user.getSessions()
-                                        .forEach(session -> handleSessionHeartbeat(user, session)));
+            .getUsers()
+            .forEach(
+                user ->
+                    user.getSessions()
+                        .forEach(session -> handleSessionHeartbeat(user, session)));
     }
 
     private void handleSessionHeartbeat(SimpUser user, SimpSession session) {
@@ -53,30 +57,38 @@ public class HeartbeatMonitor {
 
         /* ping */
         messageSender.sendPersonal(
-                getUserDestination(),
-                MessageType.HEARTBEAT,
-                new HeartbeatResponse(DIRECTION),
-                user.getName());
+            getUserDestination(),
+            MessageType.HEARTBEAT,
+            new HeartbeatResponse(DIRECTION),
+            user.getName());
 
-        // todo FE 개발 될때까지 주석 처리
-        //        missedPongCounter.merge(sessionId, 1, Integer::sum);
-        //        int missedCnt = missedPongCounter.get(sessionId);
-        //
-        //        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
-        //        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
-        //
-        //            Principal principal = user.getPrincipal();
-        //
-        //            if (principal instanceof UsernamePasswordAuthenticationToken token
-        //                    && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
-        //
-        //                Long userId = userPrincipal.getUserId();
-        //                Long roomId = roomService.getRoomIdByUserId(userId);
-        //
-        //                roomService.disconnectOrExitRoom(roomId, userPrincipal);
-        //            }
-        //            cleanSession(sessionId);
-        //        }
+        missedPongCounter.merge(sessionId, 1, Integer::sum);
+        int missedCnt = missedPongCounter.get(sessionId);
+
+        /* max_missed_heartbeats 이상 pong 이 안왔을때 - disconnect 처리 */
+        log.info("missedCnt = {}", missedCnt);
+        if (missedCnt >= MAX_MISSED_HEARTBEATS) {
+
+            Principal principal = user.getPrincipal();
+
+            if (principal instanceof UsernamePasswordAuthenticationToken token
+                && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
+
+                Long userId = userPrincipal.getUserId();
+                Long roomId = roomService.getRoomIdByUserIdWithLock(userId);
+
+                lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
+                    () -> {
+                        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
+                            () -> {
+                                roomService.disconnectOrExitRoom(roomId, userPrincipal);
+
+                            });
+                    });
+
+            }
+            cleanSession(sessionId);
+        }
     }
 
     public void resetMissedPongCount(String sessionId) {

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/HeartbeatMonitor.java
@@ -9,17 +9,20 @@ import io.f1.backend.domain.game.dto.MessageType;
 import io.f1.backend.domain.game.dto.response.HeartbeatResponse;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.lock.LockExecutor;
-import java.security.Principal;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpUser;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component
@@ -45,11 +48,11 @@ public class HeartbeatMonitor {
         }
 
         simpUserRegistry
-            .getUsers()
-            .forEach(
-                user ->
-                    user.getSessions()
-                        .forEach(session -> handleSessionHeartbeat(user, session)));
+                .getUsers()
+                .forEach(
+                        user ->
+                                user.getSessions()
+                                        .forEach(session -> handleSessionHeartbeat(user, session)));
     }
 
     private void handleSessionHeartbeat(SimpUser user, SimpSession session) {
@@ -57,10 +60,10 @@ public class HeartbeatMonitor {
 
         /* ping */
         messageSender.sendPersonal(
-            getUserDestination(),
-            MessageType.HEARTBEAT,
-            new HeartbeatResponse(DIRECTION),
-            user.getName());
+                getUserDestination(),
+                MessageType.HEARTBEAT,
+                new HeartbeatResponse(DIRECTION),
+                user.getName());
 
         missedPongCounter.merge(sessionId, 1, Integer::sum);
         int missedCnt = missedPongCounter.get(sessionId);
@@ -72,20 +75,22 @@ public class HeartbeatMonitor {
             Principal principal = user.getPrincipal();
 
             if (principal instanceof UsernamePasswordAuthenticationToken token
-                && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
+                    && token.getPrincipal() instanceof UserPrincipal userPrincipal) {
 
                 Long userId = userPrincipal.getUserId();
                 Long roomId = roomService.getRoomIdByUserIdWithLock(userId);
 
-                lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
-                    () -> {
-                        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
-                            () -> {
-                                roomService.disconnectOrExitRoom(roomId, userPrincipal);
-
-                            });
-                    });
-
+                lockExecutor.executeWithLock(
+                        USER_LOCK_PREFIX,
+                        userId,
+                        () -> {
+                            lockExecutor.executeWithLock(
+                                    ROOM_LOCK_PREFIX,
+                                    roomId,
+                                    () -> {
+                                        roomService.disconnectOrExitRoom(roomId, userPrincipal);
+                                    });
+                        });
             }
             cleanSession(sessionId);
         }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
@@ -39,7 +39,8 @@ public class GameSocketController {
     public void reconnect(@DestinationVariable Long roomId, Message<?> message) {
 
         UserPrincipal principal = getSessionUser(message);
-        roomService.changeConnectedStatusWithLock(roomId, principal.getUserId(), ConnectionState.CONNECTED);
+        roomService.changeConnectedStatusWithLock(
+                roomId, principal.getUserId(), ConnectionState.CONNECTED);
         roomService.reconnectSendResponseWithLock(roomId, principal);
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
@@ -39,7 +39,7 @@ public class GameSocketController {
     public void reconnect(@DestinationVariable Long roomId, Message<?> message) {
 
         UserPrincipal principal = getSessionUser(message);
-        roomService.changeConnectedStatus(principal.getUserId(), ConnectionState.CONNECTED);
+        roomService.changeConnectedStatus(principal.getUserId(),roomId, ConnectionState.CONNECTED);
         roomService.reconnectSendResponse(roomId, principal);
     }
 

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
@@ -39,8 +39,8 @@ public class GameSocketController {
     public void reconnect(@DestinationVariable Long roomId, Message<?> message) {
 
         UserPrincipal principal = getSessionUser(message);
-        roomService.changeConnectedStatus(roomId, principal.getUserId(), ConnectionState.CONNECTED);
-        roomService.reconnectSendResponse(roomId, principal);
+        roomService.changeConnectedStatusWithLock(roomId, principal.getUserId(), ConnectionState.CONNECTED);
+        roomService.reconnectSendResponseWithLock(roomId, principal);
     }
 
     @MessageMapping("/room/exit/{roomId}")
@@ -48,7 +48,7 @@ public class GameSocketController {
 
         UserPrincipal principal = getSessionUser(message);
 
-        roomService.exitRoom(roomId, principal);
+        roomService.exitRoomWithLock(roomId, principal);
     }
 
     @MessageMapping("/room/start/{roomId}")

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/GameSocketController.java
@@ -1,5 +1,6 @@
 package io.f1.backend.domain.game.websocket.controller;
 
+import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionId;
 import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionUser;
 
 import io.f1.backend.domain.game.app.ChatService;
@@ -33,6 +34,7 @@ public class GameSocketController {
         UserPrincipal principal = getSessionUser(message);
 
         roomService.initializeRoomSocket(roomId, principal);
+        roomService.addSessionRoomId(getSessionId(message), roomId);
     }
 
     @MessageMapping("/room/reconnect/{roomId}")
@@ -41,6 +43,7 @@ public class GameSocketController {
         UserPrincipal principal = getSessionUser(message);
         roomService.changeConnectedStatusWithLock(roomId, principal.getUserId(), ConnectionState.CONNECTED);
         roomService.reconnectSendResponseWithLock(roomId, principal);
+        roomService.addSessionRoomId(getSessionId(message), roomId);
     }
 
     @MessageMapping("/room/exit/{roomId}")

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
@@ -20,6 +20,6 @@ public class HeartbeatController {
     public void handlePong(Message<?> message) {
         String sessionId = getSessionId(message);
 
-         heartbeatMonitor.resetMissedPongCount(sessionId);
+        heartbeatMonitor.resetMissedPongCount(sessionId);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/controller/HeartbeatController.java
@@ -20,7 +20,6 @@ public class HeartbeatController {
     public void handlePong(Message<?> message) {
         String sessionId = getSessionId(message);
 
-        // todo FE 개발 될때까지 주석 처리
-        // heartbeatMonitor.resetMissedPongCount(sessionId);
+         heartbeatMonitor.resetMissedPongCount(sessionId);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -9,8 +9,8 @@ import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.websocket.DisconnectTaskManager;
 import io.f1.backend.domain.game.websocket.HeartbeatMonitor;
 import io.f1.backend.domain.user.dto.UserPrincipal;
-
 import io.f1.backend.global.lock.LockExecutor;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,24 +45,29 @@ public class WebsocketEventListener {
             return;
         }
 
-        Long roomId = lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
-            () -> roomService.getRoomIdByUserId(userId));
+        Long roomId =
+                lockExecutor.executeWithLock(
+                        USER_LOCK_PREFIX, userId, () -> roomService.getRoomIdByUserId(userId));
 
         lockExecutor.executeWithLock(
-            ROOM_LOCK_PREFIX, roomId, () -> roomService.changeConnectedStatus(roomId, userId,
-                ConnectionState.DISCONNECTED));
+                ROOM_LOCK_PREFIX,
+                roomId,
+                () ->
+                        roomService.changeConnectedStatus(
+                                roomId, userId, ConnectionState.DISCONNECTED));
 
         taskManager.scheduleDisconnectTask(
-            userId,
-            () -> {
-                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
-                    () -> {
-                        if (ConnectionState.DISCONNECTED.equals(
-                            roomService.getPlayerState(userId, roomId))) {
-                            roomService.disconnectOrExitRoom(roomId, principal);
-                        }
-                    }
-                );
-            });
+                userId,
+                () -> {
+                    lockExecutor.executeWithLock(
+                            ROOM_LOCK_PREFIX,
+                            roomId,
+                            () -> {
+                                if (ConnectionState.DISCONNECTED.equals(
+                                        roomService.getPlayerState(userId, roomId))) {
+                                    roomService.disconnectOrExitRoom(roomId, principal);
+                                }
+                            });
+                });
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -36,17 +36,21 @@ public class WebsocketEventListener {
         UserPrincipal principal = getSessionUser(message);
 
         Long userId = principal.getUserId();
+        String sessionId = event.getSessionId();
 
-        // todo FE 개발 될때까지 주석 처리
-        // heartbeatMonitor.cleanSession(event.getSessionId());
+        heartbeatMonitor.cleanSession(sessionId);
+        Long roomId = roomService.getRoomIdBySessionId(sessionId);
+        roomService.removeSessionRoomId(sessionId);
 
         /* 정상 로직 */
         if (!roomService.isUserInAnyRoom(userId)) {
             return;
         }
 
-        Long roomId = lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
-            () -> roomService.getRoomIdByUserId(userId));
+        if(!roomService.existsRoom(roomId)) {
+            return;
+        }
+
 
         lockExecutor.executeWithLock(
             ROOM_LOCK_PREFIX, roomId, () -> roomService.changeConnectedStatus(roomId, userId,
@@ -55,14 +59,16 @@ public class WebsocketEventListener {
         taskManager.scheduleDisconnectTask(
             userId,
             () -> {
-                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
+                lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
                     () -> {
-                        if (ConnectionState.DISCONNECTED.equals(
-                            roomService.getPlayerState(userId, roomId))) {
-                            roomService.disconnectOrExitRoom(roomId, principal);
-                        }
-                    }
-                );
+                        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
+                            () -> {
+                                if (ConnectionState.DISCONNECTED.equals(
+                                    roomService.getPlayerState(userId, roomId))) {
+                                    roomService.disconnectOrExitRoom(roomId, principal);
+                                }
+                            });
+                    });
             });
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -1,5 +1,7 @@
 package io.f1.backend.domain.game.websocket.eventlistener;
 
+import static io.f1.backend.domain.game.app.RoomService.ROOM_LOCK_PREFIX;
+import static io.f1.backend.domain.game.app.RoomService.USER_LOCK_PREFIX;
 import static io.f1.backend.domain.game.websocket.WebSocketUtils.getSessionUser;
 
 import io.f1.backend.domain.game.app.RoomService;
@@ -8,6 +10,7 @@ import io.f1.backend.domain.game.websocket.DisconnectTaskManager;
 import io.f1.backend.domain.game.websocket.HeartbeatMonitor;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 
+import io.f1.backend.global.lock.LockExecutor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,6 +27,7 @@ public class WebsocketEventListener {
     private final RoomService roomService;
     private final DisconnectTaskManager taskManager;
     private final HeartbeatMonitor heartbeatMonitor;
+    private final LockExecutor lockExecutor;
 
     @EventListener
     public void handleDisconnectedListener(SessionDisconnectEvent event) {
@@ -41,17 +45,24 @@ public class WebsocketEventListener {
             return;
         }
 
-        Long roomId = roomService.getRoomIdByUserId(userId);
+        Long roomId = lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
+            () -> roomService.getRoomIdByUserId(userId));
 
-        roomService.changeConnectedStatus(roomId, userId, ConnectionState.DISCONNECTED);
+        lockExecutor.executeWithLock(
+            ROOM_LOCK_PREFIX, roomId, () -> roomService.changeConnectedStatus(roomId, userId,
+                ConnectionState.DISCONNECTED));
 
         taskManager.scheduleDisconnectTask(
-                userId,
-                () -> {
-                    if (ConnectionState.DISCONNECTED.equals(
+            userId,
+            () -> {
+                lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
+                    () -> {
+                        if (ConnectionState.DISCONNECTED.equals(
                             roomService.getPlayerState(userId, roomId))) {
-                        roomService.disconnectOrExitRoom(roomId, principal);
+                            roomService.disconnectOrExitRoom(roomId, principal);
+                        }
                     }
-                });
+                );
+            });
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -7,6 +7,7 @@ import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.websocket.DisconnectTaskManager;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 
+import io.f1.backend.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,7 +37,9 @@ public class WebsocketEventListener {
             return;
         }
 
-        Long roomId = roomService.changeConnectedStatus(userId, ConnectionState.DISCONNECTED);
+        Long roomId = roomService.getUserRoomId(userId);
+
+        changeConnectionStateWithLock(userId,roomId);
 
         taskManager.scheduleDisconnectTask(
                 userId,
@@ -46,5 +49,11 @@ public class WebsocketEventListener {
                         roomService.exitIfNotPlaying(roomId, principal);
                     }
                 });
+    }
+
+
+    @DistributedLock(prefix = "room", key = "#roomId")
+    private void changeConnectionStateWithLock(Long userId, Long roomId){
+        roomService.changeConnectedStatus(userId,roomId ,ConnectionState.DISCONNECTED);
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/websocket/eventlistener/WebsocketEventListener.java
@@ -9,8 +9,8 @@ import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.websocket.DisconnectTaskManager;
 import io.f1.backend.domain.game.websocket.HeartbeatMonitor;
 import io.f1.backend.domain.user.dto.UserPrincipal;
-
 import io.f1.backend.global.lock.LockExecutor;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,28 +47,34 @@ public class WebsocketEventListener {
             return;
         }
 
-        if(!roomService.existsRoom(roomId)) {
+        if (!roomService.existsRoom(roomId)) {
             return;
         }
 
-
         lockExecutor.executeWithLock(
-            ROOM_LOCK_PREFIX, roomId, () -> roomService.changeConnectedStatus(roomId, userId,
-                ConnectionState.DISCONNECTED));
+                ROOM_LOCK_PREFIX,
+                roomId,
+                () ->
+                        roomService.changeConnectedStatus(
+                                roomId, userId, ConnectionState.DISCONNECTED));
 
         taskManager.scheduleDisconnectTask(
-            userId,
-            () -> {
-                lockExecutor.executeWithLock(USER_LOCK_PREFIX, userId,
-                    () -> {
-                        lockExecutor.executeWithLock(ROOM_LOCK_PREFIX, roomId,
+                userId,
+                () -> {
+                    lockExecutor.executeWithLock(
+                            USER_LOCK_PREFIX,
+                            userId,
                             () -> {
-                                if (ConnectionState.DISCONNECTED.equals(
-                                    roomService.getPlayerState(userId, roomId))) {
-                                    roomService.disconnectOrExitRoom(roomId, principal);
-                                }
+                                lockExecutor.executeWithLock(
+                                        ROOM_LOCK_PREFIX,
+                                        roomId,
+                                        () -> {
+                                            if (ConnectionState.DISCONNECTED.equals(
+                                                    roomService.getPlayerState(userId, roomId))) {
+                                                roomService.disconnectOrExitRoom(roomId, principal);
+                                            }
+                                        });
                             });
-                    });
-            });
+                });
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
@@ -13,7 +13,9 @@ public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(
             "E500001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러가 발생했습니다. 관리자에게 문의해주세요."),
     INVALID_JSON_FORMAT("E400008", HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다. JSON 문법을 확인해주세요."),
-    LOCK_ACQUISITION_FAILED("E409003", HttpStatus.CONFLICT, "다른 요청이 작업 중입니다. 잠시 후 다시 시도해주세요.");
+    LOCK_ACQUISITION_FAILED("E409003", HttpStatus.CONFLICT, "다른 요청이 작업 중입니다. 잠시 후 다시 시도해주세요."),
+    LOCK_INTERRUPTED("E500004", HttpStatus.INTERNAL_SERVER_ERROR, "작업 중 락 획득이 중단되었습니다. 다시 시도해주세요.");
+
 
     private final String code;
 

--- a/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/errorcode/CommonErrorCode.java
@@ -16,7 +16,6 @@ public enum CommonErrorCode implements ErrorCode {
     LOCK_ACQUISITION_FAILED("E409003", HttpStatus.CONFLICT, "다른 요청이 작업 중입니다. 잠시 후 다시 시도해주세요."),
     LOCK_INTERRUPTED("E500004", HttpStatus.INTERNAL_SERVER_ERROR, "작업 중 락 획득이 중단되었습니다. 다시 시도해주세요.");
 
-
     private final String code;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import io.f1.backend.global.exception.errorcode.ErrorCode;
 import io.f1.backend.global.exception.response.ErrorResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/f1/backend/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import io.f1.backend.global.exception.errorcode.CommonErrorCode;
 import io.f1.backend.global.exception.errorcode.ErrorCode;
 import io.f1.backend.global.exception.response.ErrorResponse;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
@@ -28,8 +29,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.warn("handleException: {}", e.getMessage());
+
+        if ("text/event-stream".equals(request.getHeader("Accept"))) {
+            return ResponseEntity.noContent().build();
+        }
+
         CommonErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
 
         ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());

--- a/backend/src/main/java/io/f1/backend/global/lock/DistributedLockAspect.java
+++ b/backend/src/main/java/io/f1/backend/global/lock/DistributedLockAspect.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DistributedLockAspect {
 
-    private static final String LOCK_KEY_FORMAT = "lock:%s:{%s}";
+    public static final String LOCK_KEY_FORMAT = "lock:%s:{%s}";
 
     private final RedissonClient redissonClient;
 

--- a/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
+++ b/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
@@ -4,13 +4,16 @@ import static io.f1.backend.global.lock.DistributedLockAspect.LOCK_KEY_FORMAT;
 
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.CommonErrorCode;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @Slf4j
 @Component
@@ -36,7 +39,7 @@ public class LockExecutor {
         try {
             acquired = rlock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME, DEFAULT_TIME_UNIT);
 
-            if(!acquired) {
+            if (!acquired) {
                 log.warn("[LockExecutor] Lock acquisition failed: {}", key);
                 throw new CustomException(CommonErrorCode.LOCK_ACQUISITION_FAILED);
             }
@@ -55,12 +58,14 @@ public class LockExecutor {
     }
 
     public void executeWithLock(String prefix, Object key, Runnable runnable) {
-        executeWithLock(prefix, key, () -> {
-            runnable.run();
-            return null;
-        });
+        executeWithLock(
+                prefix,
+                key,
+                () -> {
+                    runnable.run();
+                    return null;
+                });
     }
-
 
     private String formatLockKey(String prefix, Object value) {
         return String.format(LOCK_KEY_FORMAT, prefix, value);

--- a/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
+++ b/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
@@ -4,13 +4,16 @@ import static io.f1.backend.global.lock.DistributedLockAspect.LOCK_KEY_FORMAT;
 
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.CommonErrorCode;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @Slf4j
 @Component
@@ -36,7 +39,7 @@ public class LockExecutor {
         try {
             acquired = rlock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME, DEFAULT_TIME_UNIT);
 
-            if(!acquired) {
+            if (!acquired) {
                 log.warn("[DistributedLock] Lock acquisition failed: {}", key);
                 throw new CustomException(CommonErrorCode.LOCK_ACQUISITION_FAILED);
             }
@@ -55,12 +58,14 @@ public class LockExecutor {
     }
 
     public void executeWithLock(String prefix, Object key, Runnable runnable) {
-        executeWithLock(prefix, key, () -> {
-            runnable.run();
-            return null;
-        });
+        executeWithLock(
+                prefix,
+                key,
+                () -> {
+                    runnable.run();
+                    return null;
+                });
     }
-
 
     private String formatLockKey(String prefix, Object value) {
         return String.format(LOCK_KEY_FORMAT, prefix, value);

--- a/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
+++ b/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
@@ -1,0 +1,68 @@
+package io.f1.backend.global.lock;
+
+import static io.f1.backend.global.lock.DistributedLockAspect.LOCK_KEY_FORMAT;
+
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.CommonErrorCode;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LockExecutor {
+
+    private final RedissonClient redissonClient;
+
+    // 시간단위를 초로 변경
+    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
+
+    // 락 점유를 위한 대기 시간
+    private static final long DEFAULT_WAIT_TIME = 5L;
+
+    // 락 점유 시간
+    private static final long DEFAULT_LEASE_TIME = 3L;
+
+    public <T> T executeWithLock(String prefix, Object key, Supplier<T> supplier) {
+        String lockKey = formatLockKey(prefix, key);
+        RLock rlock = redissonClient.getLock(lockKey);
+
+        boolean acquired = false;
+        try {
+            acquired = rlock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME, DEFAULT_TIME_UNIT);
+
+            if(!acquired) {
+                log.warn("[DistributedLock] Lock acquisition failed: {}", key);
+                throw new CustomException(CommonErrorCode.LOCK_ACQUISITION_FAILED);
+            }
+            log.info("[DistributedLock] Lock acquired: {}", key);
+
+            return supplier.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(CommonErrorCode.LOCK_INTERRUPTED);
+        } finally {
+            if (acquired && rlock.isHeldByCurrentThread()) {
+                rlock.unlock();
+                log.info("[DistributedLock] Lock released: {}", key);
+            }
+        }
+    }
+
+    public void executeWithLock(String prefix, Object key, Runnable runnable) {
+        executeWithLock(prefix, key, () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+
+    private String formatLockKey(String prefix, Object value) {
+        return String.format(LOCK_KEY_FORMAT, prefix, value);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
+++ b/backend/src/main/java/io/f1/backend/global/lock/LockExecutor.java
@@ -37,10 +37,10 @@ public class LockExecutor {
             acquired = rlock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME, DEFAULT_TIME_UNIT);
 
             if(!acquired) {
-                log.warn("[DistributedLock] Lock acquisition failed: {}", key);
+                log.warn("[LockExecutor] Lock acquisition failed: {}", key);
                 throw new CustomException(CommonErrorCode.LOCK_ACQUISITION_FAILED);
             }
-            log.info("[DistributedLock] Lock acquired: {}", key);
+            log.info("[LockExecutor] Lock acquired: {}", key);
 
             return supplier.get();
         } catch (InterruptedException e) {
@@ -49,7 +49,7 @@ public class LockExecutor {
         } finally {
             if (acquired && rlock.isHeldByCurrentThread()) {
                 rlock.unlock();
-                log.info("[DistributedLock] Lock released: {}", key);
+                log.info("[LockExecutor] Lock released: {}", key);
             }
         }
     }

--- a/backend/src/test/java/io/f1/backend/domain/game/app/GameFlowTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/GameFlowTests.java
@@ -222,7 +222,7 @@ class GameFlowTests {
         private final Map<Long, Room> rooms = new ConcurrentHashMap<>();
 
         public TestRoomService() {
-            super(null, null, null, null, null, null);
+            super(null, null, null, null, null, null,null);
         }
 
         @Override

--- a/backend/src/test/java/io/f1/backend/domain/game/app/GameFlowTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/GameFlowTests.java
@@ -222,7 +222,7 @@ class GameFlowTests {
         private final Map<Long, Room> rooms = new ConcurrentHashMap<>();
 
         public TestRoomService() {
-            super(null, null, null, null, null, null,null);
+            super(null, null, null, null, null, null, null);
         }
 
         @Override

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -25,23 +25,9 @@ import io.f1.backend.global.config.RedisTestContainerConfig;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.RoomErrorCode;
 import io.f1.backend.global.lock.LockExecutor;
-import java.time.LocalDateTime;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,6 +45,22 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 @Slf4j
 @SpringBootTest
 @Import({RedisTestContainerConfig.class}) // Redis Testcontainers 설정 임포트
@@ -68,8 +70,8 @@ class RoomServiceConcurrentTest {
     static void redisProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.data.redis.host", RedisTestContainerConfig.redisContainer::getHost);
         registry.add(
-            "spring.data.redis.port",
-            () -> RedisTestContainerConfig.redisContainer.getFirstMappedPort());
+                "spring.data.redis.port",
+                () -> RedisTestContainerConfig.redisContainer.getFirstMappedPort());
     }
 
     @Mock private QuizService quizService;
@@ -96,15 +98,16 @@ class RoomServiceConcurrentTest {
         // RoomService에 실제 구현체 주입
         ReflectionTestUtils.setField(roomService, "roomRepository", roomRepository);
         ReflectionTestUtils.setField(roomService, "userRoomRepository", userRoomRepository);
-        ReflectionTestUtils.setField(roomService, "roomIdGenerator", new AtomicLong(0)); // ID 생성기 초기화
+        ReflectionTestUtils.setField(
+                roomService, "roomIdGenerator", new AtomicLong(0)); // ID 생성기 초기화
         ReflectionTestUtils.setField(roomService, "lockExecutor", lockExecutor);
         ReflectionTestUtils.setField(roomService, "quizService", quizService);
-
 
         Quiz dummyQuiz = mock(Quiz.class);
         when(dummyQuiz.getId()).thenReturn(1L);
         when(quizService.getQuizWithQuestionsById(anyLong())).thenReturn(dummyQuiz);
-        when(quizService.getQuizMinData()).thenReturn(new QuizMinData(1L, 10L));   doNothing().when(eventPublisher).publishEvent(any());
+        when(quizService.getQuizMinData()).thenReturn(new QuizMinData(1L, 10L));
+        doNothing().when(eventPublisher).publishEvent(any());
         doNothing().when(disconnectTasks).cancelDisconnectTask(any(Long.class));
         doNothing().when(messageSender).sendPersonal(any(), any(), any(), any());
         doNothing().when(messageSender).sendBroadcast(any(), any(), any());
@@ -122,7 +125,7 @@ class RoomServiceConcurrentTest {
         String hostNickname = "host";
 
         // Room 생성 (호스트 포함 1명)
-       createAndSaveRoom(roomId,100L,hostNickname,maxUserCount);
+        createAndSaveRoom(roomId, 100L, hostNickname, maxUserCount);
 
         int numConcurrentUsers = 10; // 동시 입장 시도할 사용자 수
         ExecutorService executorService = Executors.newFixedThreadPool(numConcurrentUsers);
@@ -140,33 +143,42 @@ class RoomServiceConcurrentTest {
 
             RoomValidationRequest request = new RoomValidationRequest(roomId, null);
 
-            executorService.submit(() -> {
+            executorService.submit(
+                    () -> {
+                        UsernamePasswordAuthenticationToken authentication =
+                                new UsernamePasswordAuthenticationToken(
+                                        userPrincipal, null, Collections.emptyList());
+                        SecurityContext context = SecurityContextHolder.createEmptyContext();
+                        context.setAuthentication(authentication);
+                        SecurityContextHolder.setContext(context);
 
-                UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
-                SecurityContext context = SecurityContextHolder.createEmptyContext();
-                context.setAuthentication(authentication);
-                SecurityContextHolder.setContext(context);
-
-                try {
-                    startLatch.await(); // 모든 스레드가 동시에 시작하도록 대기
-                    roomService.enterRoom(request);
-                    successEntries.incrementAndGet();
-                } catch (CustomException e) {
-                    if (e.getErrorCode() == RoomErrorCode.ROOM_USER_LIMIT_REACHED) {
-                        failedEntries.incrementAndGet();
-                    } else {
-                        log.info("Unexpected CustomException in enterRoom for user {}: {}", userPrincipal.getUserId(), e.getMessage(), e);
-                        failedEntries.incrementAndGet();
-                    }
-                } catch (Exception e) {
-                    log.info("Unhandled Exception in enterRoom for user {}: {}", userPrincipal.getUserId(), e.getMessage(), e); // 여기에 예외 상세 로그
-                    failedEntries.incrementAndGet();
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+                        try {
+                            startLatch.await(); // 모든 스레드가 동시에 시작하도록 대기
+                            roomService.enterRoom(request);
+                            successEntries.incrementAndGet();
+                        } catch (CustomException e) {
+                            if (e.getErrorCode() == RoomErrorCode.ROOM_USER_LIMIT_REACHED) {
+                                failedEntries.incrementAndGet();
+                            } else {
+                                log.info(
+                                        "Unexpected CustomException in enterRoom for user {}: {}",
+                                        userPrincipal.getUserId(),
+                                        e.getMessage(),
+                                        e);
+                                failedEntries.incrementAndGet();
+                            }
+                        } catch (Exception e) {
+                            log.info(
+                                    "Unhandled Exception in enterRoom for user {}: {}",
+                                    userPrincipal.getUserId(),
+                                    e.getMessage(),
+                                    e); // 여기에 예외 상세 로그
+                            failedEntries.incrementAndGet();
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
         }
 
         startLatch.countDown(); // 모든 스레드 시작!
@@ -194,14 +206,14 @@ class RoomServiceConcurrentTest {
 
     @Test
     @DisplayName("동일 유저가 여러 탭에서 동시 초기화 요청 시 데드락 없이 처리되고, 최종적으로 하나의 방에만 존재 (가장 마지막에 시도한 방)")
-    void initializeRoomSocket_concurrently_sameUser_noDeadlockAndConsistency() throws InterruptedException {
+    void initializeRoomSocket_concurrently_sameUser_noDeadlockAndConsistency()
+            throws InterruptedException {
         // Given
         Long roomId1 = 1L;
         Long roomId2 = 2L;
         Long testUserId = 1000L; // 테스트 대상 유저 ID
         String nickname = "TestUser";
         int maxUserCount = 4;
-
 
         UserPrincipal userPrincipal = createUserPrincipal(testUserId);
 
@@ -223,44 +235,58 @@ class RoomServiceConcurrentTest {
 
         AtomicInteger successCount = new AtomicInteger(0);
         // 가장 마지막에 성공적으로 초기화된 방의 ID를 추적
-        List<AbstractMap.SimpleEntry<Long, Long>> successfulInitAttempts = Collections.synchronizedList(new ArrayList<>());
-
+        List<AbstractMap.SimpleEntry<Long, Long>> successfulInitAttempts =
+                Collections.synchronizedList(new ArrayList<>());
 
         // When
         for (int i = 0; i < numAttempts; i++) {
             // Room1 초기화 시도
-            executorService.submit(() -> {
-               setSecurityContext(userPrincipal);
-                try {
-                    startLatch.await();
-                    long callTimestamp = System.nanoTime(); // 호출 시작 시간 기록
-                    roomService.initializeRoomSocket(roomId1, userPrincipal);
-                    successCount.incrementAndGet();
-                    successfulInitAttempts.add(new AbstractMap.SimpleEntry<>(roomId1, callTimestamp));
-                } catch (Exception e) {
-                    log.error("Room1 init failed for user {} in room {}: {}", userPrincipal.getUserId(), roomId1, e.getMessage(), e);
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+            executorService.submit(
+                    () -> {
+                        setSecurityContext(userPrincipal);
+                        try {
+                            startLatch.await();
+                            long callTimestamp = System.nanoTime(); // 호출 시작 시간 기록
+                            roomService.initializeRoomSocket(roomId1, userPrincipal);
+                            successCount.incrementAndGet();
+                            successfulInitAttempts.add(
+                                    new AbstractMap.SimpleEntry<>(roomId1, callTimestamp));
+                        } catch (Exception e) {
+                            log.error(
+                                    "Room1 init failed for user {} in room {}: {}",
+                                    userPrincipal.getUserId(),
+                                    roomId1,
+                                    e.getMessage(),
+                                    e);
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
 
             // Room2 초기화 시도
-            executorService.submit(() -> {
-                setSecurityContext(userPrincipal);
-                try {
-                    startLatch.await();
-                    long callTimestamp = System.nanoTime(); // 호출 시작 시간 기록
-                    roomService.initializeRoomSocket(roomId2, userPrincipal);
-                    successCount.incrementAndGet();
-                    successfulInitAttempts.add(new AbstractMap.SimpleEntry<>(roomId2, callTimestamp));
-                } catch (Exception e) {
-                    log.error("Room2 init failed for user {} in room {}: {}", userPrincipal.getUserId(), roomId2, e.getMessage(), e);
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+            executorService.submit(
+                    () -> {
+                        setSecurityContext(userPrincipal);
+                        try {
+                            startLatch.await();
+                            long callTimestamp = System.nanoTime(); // 호출 시작 시간 기록
+                            roomService.initializeRoomSocket(roomId2, userPrincipal);
+                            successCount.incrementAndGet();
+                            successfulInitAttempts.add(
+                                    new AbstractMap.SimpleEntry<>(roomId2, callTimestamp));
+                        } catch (Exception e) {
+                            log.error(
+                                    "Room2 init failed for user {} in room {}: {}",
+                                    userPrincipal.getUserId(),
+                                    roomId2,
+                                    e.getMessage(),
+                                    e);
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
         }
 
         startLatch.countDown();
@@ -278,13 +304,14 @@ class RoomServiceConcurrentTest {
         successfulInitAttempts.sort(Comparator.comparing(AbstractMap.SimpleEntry::getValue));
         Long expectedFinalRoomId = null;
         if (!successfulInitAttempts.isEmpty()) {
-            expectedFinalRoomId = successfulInitAttempts.get(successfulInitAttempts.size() - 1).getKey();
+            expectedFinalRoomId =
+                    successfulInitAttempts.get(successfulInitAttempts.size() - 1).getKey();
         }
 
         // 최종적으로 저장된 방 ID가 가장 마지막에 성공적으로 시도된 방 ID와 일치하는지 검증
         assertThat(finalRoomId)
-            .as("Final room must be the one from the last successful initialization attempt")
-            .isEqualTo(expectedFinalRoomId);
+                .as("Final room must be the one from the last successful initialization attempt")
+                .isEqualTo(expectedFinalRoomId);
 
         // 각 방의 상태 검증
         Room finalRoom1 = roomRepository.findRoom(roomId1).orElse(null);
@@ -311,7 +338,6 @@ class RoomServiceConcurrentTest {
         }
     }
 
-
     @Test
     @DisplayName("다수의 사용자가 동시 입장/나가기 시도 시 데드락 없이 정합성 유지")
     void enterAndExit_concurrently_noDeadlockAndConsistency() throws InterruptedException {
@@ -335,36 +361,39 @@ class RoomServiceConcurrentTest {
             RoomValidationRequest enterRequest = new RoomValidationRequest(roomId, null);
 
             // 입장 스레드
-            executorService.submit(() -> {
-                UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
-                SecurityContext context = SecurityContextHolder.createEmptyContext();
-                context.setAuthentication(authentication);
-                SecurityContextHolder.setContext(context);
-                try {
-                    startLatch.await();
-                    roomService.enterRoom(enterRequest);
-                } catch (Exception e) {
-                    // 예상되는 예외: ROOM_USER_LIMIT_REACHED
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+            executorService.submit(
+                    () -> {
+                        UsernamePasswordAuthenticationToken authentication =
+                                new UsernamePasswordAuthenticationToken(
+                                        userPrincipal, null, Collections.emptyList());
+                        SecurityContext context = SecurityContextHolder.createEmptyContext();
+                        context.setAuthentication(authentication);
+                        SecurityContextHolder.setContext(context);
+                        try {
+                            startLatch.await();
+                            roomService.enterRoom(enterRequest);
+                        } catch (Exception e) {
+                            // 예상되는 예외: ROOM_USER_LIMIT_REACHED
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
 
             // 나가기 스레드 (입장 시도 후 바로 나가기 시도)
-            executorService.submit(() -> {
-                setSecurityContext(userPrincipal);
-                try {
-                    startLatch.await();
-                    roomService.exitRoomWithLock(roomId, userPrincipal);
-                } catch (Exception e) {
-                    // 예상되는 예외: USER_NOT_FOUND (아직 입장하지 못했을 때)
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+            executorService.submit(
+                    () -> {
+                        setSecurityContext(userPrincipal);
+                        try {
+                            startLatch.await();
+                            roomService.exitRoomWithLock(roomId, userPrincipal);
+                        } catch (Exception e) {
+                            // 예상되는 예외: USER_NOT_FOUND (아직 입장하지 못했을 때)
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
         }
 
         startLatch.countDown();
@@ -381,9 +410,9 @@ class RoomServiceConcurrentTest {
         // 예를 들어, 어떤 유저가 입장 직후 바로 나가는 데 성공하면 0이 될 수도 있고,
         // 어떤 유저가 입장만 성공하고 나가기는 실패할 수도 있음.
         // 여기서는 데드락이 없고, 불필요한 예외가 발생하지 않으며, 최소한의 정합성(호스트 존재)만 확인.
-        System.out.println("Final user count in room " + roomId + ": " + finalRoom.getCurrentUserCnt());
+        System.out.println(
+                "Final user count in room " + roomId + ": " + finalRoom.getCurrentUserCnt());
     }
-
 
     @Test
     @DisplayName("연결 끊긴 플레이어 처리 로직과 사용자 직접 나가기 로직 동시 호출 시 데드락 없음")
@@ -400,7 +429,8 @@ class RoomServiceConcurrentTest {
         // Room 생성
         // 방 생성 및 플레이어 추가 - 헬퍼 메서드 사용
         Room room = createAndSaveRoom(roomId, hostId, "Host", maxUserCount);
-        Player disconnectedPlayer = createPlayer(disconnectedUserId, "DisconnectedUser"); // 헬퍼 메서드 사용
+        Player disconnectedPlayer =
+                createPlayer(disconnectedUserId, "DisconnectedUser"); // 헬퍼 메서드 사용
         Player exitingPlayer = createPlayer(exitingUserId, "ExitingUser"); // 헬퍼 메서드 사용
 
         room.addPlayer(disconnectedPlayer);
@@ -424,34 +454,36 @@ class RoomServiceConcurrentTest {
             long userId = (long) i + 201;
             UserPrincipal disconnectedUserPrincipal = createUserPrincipal(disconnectedUserId);
             // disconnectOrExitRoom (플레이어 연결 끊김 시뮬레이션)
-            executorService.submit(() -> {
-                setSecurityContext(disconnectedUserPrincipal);
-                try {
-                    startLatch.await();
-                    roomService.disconnectOrExitRoom(roomId, disconnectedUserPrincipal);
-                } catch (Exception e) {
-                    System.err.println("Disconnect error: " + e.getMessage());
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+            executorService.submit(
+                    () -> {
+                        setSecurityContext(disconnectedUserPrincipal);
+                        try {
+                            startLatch.await();
+                            roomService.disconnectOrExitRoom(roomId, disconnectedUserPrincipal);
+                        } catch (Exception e) {
+                            System.err.println("Disconnect error: " + e.getMessage());
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
 
             UserPrincipal exitingUserPrincipal = createUserPrincipal(exitingUserId);
 
             // exitRoomWithLock (사용자 직접 나가기 시뮬레이션)
-            executorService.submit(() -> {
-               setSecurityContext(exitingUserPrincipal);
-                try {
-                    startLatch.await();
-                    roomService.exitRoomWithLock(roomId, exitingUserPrincipal);
-                } catch (Exception e) {
-                    System.err.println("Exit error: " + e.getMessage());
-                } finally {
-                    SecurityContextHolder.clearContext();
-                    finishLatch.countDown();
-                }
-            });
+            executorService.submit(
+                    () -> {
+                        setSecurityContext(exitingUserPrincipal);
+                        try {
+                            startLatch.await();
+                            roomService.exitRoomWithLock(roomId, exitingUserPrincipal);
+                        } catch (Exception e) {
+                            System.err.println("Exit error: " + e.getMessage());
+                        } finally {
+                            SecurityContextHolder.clearContext();
+                            finishLatch.countDown();
+                        }
+                    });
         }
 
         startLatch.countDown();
@@ -475,11 +507,9 @@ class RoomServiceConcurrentTest {
         assertThat(finalRoom.getCurrentUserCnt()).isEqualTo(1);
     }
 
-
     private Player createPlayer(Long userId, String nickname) {
         return new Player(userId, nickname);
     }
-
 
     private UserPrincipal createUserPrincipal(Long userId) {
         User user = new User("kakao", "providerId_" + userId, LocalDateTime.now());
@@ -487,8 +517,8 @@ class RoomServiceConcurrentTest {
         return new UserPrincipal(user, Collections.emptyMap());
     }
 
-
-    private Room createAndSaveRoom(Long roomId, Long hostId, String hostNickname, int maxUserCount) {
+    private Room createAndSaveRoom(
+            Long roomId, Long hostId, String hostNickname, int maxUserCount) {
         RoomSetting roomSetting = new RoomSetting("testRoom", maxUserCount, false, null);
         Player host = createPlayer(hostId, hostNickname);
         Room room = new Room(roomId, roomSetting, new GameSetting(1L, 10, 3), host);
@@ -500,7 +530,8 @@ class RoomServiceConcurrentTest {
 
     private void setSecurityContext(UserPrincipal userPrincipal) {
         UsernamePasswordAuthenticationToken authentication =
-            new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
+                new UsernamePasswordAuthenticationToken(
+                        userPrincipal, null, Collections.emptyList());
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
@@ -532,5 +563,4 @@ class RoomServiceConcurrentTest {
             rooms.remove(roomId);
         }
     }
-
 }

--- a/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
+++ b/backend/src/test/java/io/f1/backend/domain/game/app/RoomServiceTests.java
@@ -1,8 +1,13 @@
 package io.f1.backend.domain.game.app;
 
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.f1.backend.domain.game.dto.request.RoomValidationRequest;
 import io.f1.backend.domain.game.model.GameSetting;
 import io.f1.backend.domain.game.model.Player;
 import io.f1.backend.domain.game.model.Room;
@@ -12,205 +17,520 @@ import io.f1.backend.domain.game.store.UserRoomRepository;
 import io.f1.backend.domain.game.websocket.DisconnectTaskManager;
 import io.f1.backend.domain.game.websocket.MessageSender;
 import io.f1.backend.domain.quiz.app.QuizService;
+import io.f1.backend.domain.quiz.dto.QuizMinData;
+import io.f1.backend.domain.quiz.entity.Quiz;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.domain.user.entity.User;
-import io.f1.backend.global.security.util.SecurityUtils;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.lang.reflect.Field;
+import io.f1.backend.global.config.RedisTestContainerConfig;
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.RoomErrorCode;
+import io.f1.backend.global.lock.LockExecutor;
 import java.time.LocalDateTime;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @Slf4j
-@ExtendWith(MockitoExtension.class)
-class RoomServiceTests {
+@SpringBootTest
+@Import({RedisTestContainerConfig.class}) // Redis Testcontainers 설정 임포트
+class RoomServiceConcurrentTest {
 
-    private RoomService roomService;
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", RedisTestContainerConfig.redisContainer::getHost);
+        registry.add(
+            "spring.data.redis.port",
+            () -> RedisTestContainerConfig.redisContainer.getFirstMappedPort());
+    }
 
-    @Mock private RoomRepository roomRepository;
     @Mock private QuizService quizService;
-    @Mock private UserRoomRepository userRoomRepository;
     @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private DisconnectTaskManager disconnectTasks;
     @Mock private MessageSender messageSender;
-    @Mock private DisconnectTaskManager disconnectTaskManager;
+
+    // RoomRepository와 UserRoomRepository는 실제 Map 기반 구현체를 사용
+    private RoomRepository roomRepository;
+    private UserRoomRepository userRoomRepository;
+
+    @Autowired private LockExecutor lockExecutor;
+
+    @InjectMocks private RoomService roomService;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this); // @Mock 어노테이션이 붙은 필드들을 초기화합니다.
+        MockitoAnnotations.openMocks(this);
 
-        roomService =
-                new RoomService(
-                        quizService,
-                        roomRepository,
-                        userRoomRepository,
-                        eventPublisher,
-                        disconnectTaskManager,
-                        messageSender);
+        // RoomRepository 및 UserRoomRepository의 인메모리 구현체 초기화
+        this.roomRepository = new InMemoryRoomRepository();
+        this.userRoomRepository = new UserRoomRepository();
 
-        SecurityContextHolder.clearContext();
+        // RoomService에 실제 구현체 주입
+        ReflectionTestUtils.setField(roomService, "roomRepository", roomRepository);
+        ReflectionTestUtils.setField(roomService, "userRoomRepository", userRoomRepository);
+        ReflectionTestUtils.setField(roomService, "roomIdGenerator", new AtomicLong(0)); // ID 생성기 초기화
+        ReflectionTestUtils.setField(roomService, "lockExecutor", lockExecutor);
+        ReflectionTestUtils.setField(roomService, "quizService", quizService);
+
+
+        Quiz dummyQuiz = mock(Quiz.class);
+        when(dummyQuiz.getId()).thenReturn(1L);
+        when(quizService.getQuizWithQuestionsById(anyLong())).thenReturn(dummyQuiz);
+        when(quizService.getQuizMinData()).thenReturn(new QuizMinData(1L, 10L));   doNothing().when(eventPublisher).publishEvent(any());
+        doNothing().when(disconnectTasks).cancelDisconnectTask(any(Long.class));
+        doNothing().when(messageSender).sendPersonal(any(), any(), any(), any());
+        doNothing().when(messageSender).sendBroadcast(any(), any(), any());
     }
 
-    @AfterEach
-    void afterEach() {
-        SecurityContextHolder.clearContext();
-    }
-
-    //    @Test
-    //    @DisplayName("enterRoom_동시성_테스트")
-    //    void enterRoom_synchronized() throws Exception {
-    //        Long roomId = 1L;
-    //        Long quizId = 1L;
-    //        Long playerId = 1L;
-    //        int maxUserCount = 5;
-    //        String password = "123";
-    //        boolean locked = true;
-    //
-    //        Room room = createRoom(roomId, playerId, quizId, password, maxUserCount, locked);
-    //
-    //        when(roomRepository.findRoom(roomId)).thenReturn(Optional.of(room));
-    //
-    //        int threadCount = 10;
-    //        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-    //        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-    //        RoomValidationRequest roomValidationRequest = new RoomValidationRequest(roomId,
-    // password);
-    //
-    //        for (int i = 1; i <= threadCount; i++) {
-    //            User user = createUser(i);
-    //            when(userRoomRepository.getRoomId(user.getId())).thenReturn(null);
-    //            executorService.submit(
-    //                    () -> {
-    //                        try {
-    //                            SecurityUtils.setAuthentication(user);
-    //
-    //                            roomService.enterRoom(roomValidationRequest);
-    //                        } catch (Exception e) {
-    //                            //e.printStackTrace();
-    //                        } finally {
-    //                            SecurityContextHolder.clearContext();
-    //                            countDownLatch.countDown();
-    //                        }
-    //                    });
-    //        }
-    //        countDownLatch.await();
-    //        assertThat(room.getCurrentUserCnt()).isEqualTo(room.getRoomSetting().maxUserCount());
-    //    }
+    // --- 테스트 시나리오 시작 ---
 
     @Test
-    @DisplayName("exitRoom_동시성_테스트")
-    void exitRoom_synchronized() throws Exception {
+    @DisplayName("다수의 사용자가 동시 입장 시도 시 데드락 없이 정합성 유지")
+    void enterRoom_concurrently_noDeadlockAndConsistency() throws InterruptedException {
+        // Given
         Long roomId = 1L;
-        Long quizId = 1L;
-        Long playerId = 1L;
-        int maxUserCount = 5;
-        String password = "123";
-        boolean locked = true;
+        int maxUserCount = 4;
+        Long hostId = 100L;
+        String hostNickname = "host";
 
-        /* 방 생성 */
-        Room room = createRoom(roomId, playerId, quizId, password, maxUserCount, locked);
+        // Room 생성 (호스트 포함 1명)
+       createAndSaveRoom(roomId,100L,hostNickname,maxUserCount);
 
-        int threadCount = 10;
+        int numConcurrentUsers = 10; // 동시 입장 시도할 사용자 수
+        ExecutorService executorService = Executors.newFixedThreadPool(numConcurrentUsers);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(numConcurrentUsers);
 
-        List<Player> players = new ArrayList<>();
-        for (int i = 1; i <= threadCount; i++) {
-            Long id = i + 1L;
-            String nickname = "nickname " + i;
+        AtomicInteger successEntries = new AtomicInteger(0);
+        AtomicInteger failedEntries = new AtomicInteger(0);
 
-            Player player = new Player(id, nickname);
-            players.add(player);
+        // When
+        for (int i = 0; i < numConcurrentUsers; i++) {
+            long userId = (long) i + 101; // 호스트와 겹치지 않게
+
+            UserPrincipal userPrincipal = createUserPrincipal(userId);
+
+            RoomValidationRequest request = new RoomValidationRequest(roomId, null);
+
+            executorService.submit(() -> {
+
+                UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                context.setAuthentication(authentication);
+                SecurityContextHolder.setContext(context);
+
+                try {
+                    startLatch.await(); // 모든 스레드가 동시에 시작하도록 대기
+                    roomService.enterRoom(request);
+                    successEntries.incrementAndGet();
+                } catch (CustomException e) {
+                    if (e.getErrorCode() == RoomErrorCode.ROOM_USER_LIMIT_REACHED) {
+                        failedEntries.incrementAndGet();
+                    } else {
+                        log.info("Unexpected CustomException in enterRoom for user {}: {}", userPrincipal.getUserId(), e.getMessage(), e);
+                        failedEntries.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    log.info("Unhandled Exception in enterRoom for user {}: {}", userPrincipal.getUserId(), e.getMessage(), e); // 여기에 예외 상세 로그
+                    failedEntries.incrementAndGet();
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
         }
-        Player host = players.getFirst();
-        room.updateHost(host);
 
-        /* 방 입장 */
-        for (int i = 1; i <= threadCount; i++) {
-            Player player = players.get(i - 1);
-            room.getPlayerMap().put(player.id, player);
+        startLatch.countDown(); // 모든 스레드 시작!
+        assertThat(finishLatch.await(50, TimeUnit.SECONDS)).isTrue(); // 모든 스레드 완료 대기
+
+        executorService.shutdown();
+        assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue(); // 데드락 방지 확인
+
+        // Then
+        // 호스트 1명 + 성공적인 입장 플레이어 = 최대 인원수
+        assertThat(successEntries.get()).isEqualTo(maxUserCount - 1);
+        assertThat(failedEntries.get()).isEqualTo(numConcurrentUsers - (maxUserCount - 1));
+
+        Room finalRoom = roomRepository.findRoom(roomId).orElseThrow();
+        assertThat(finalRoom.getCurrentUserCnt()).isEqualTo(maxUserCount); // 최종 인원수 확인
+        assertThat(finalRoom.getPlayerMap().size()).isEqualTo(maxUserCount); // 플레이어 맵 사이즈 확인
+
+        for (long i = 0; i < numConcurrentUsers; i++) {
+            long userId = (long) i + 101;
+            if (userRoomRepository.isUserInAnyRoom(userId)) {
+                assertThat(userRoomRepository.getRoomId(userId)).isEqualTo(roomId);
+            }
         }
-
-        log.info("room.getPlayerSessionMap().size() = {}", room.getPlayerMap().size());
-
-        when(roomRepository.findRoom(roomId)).thenReturn(Optional.of(room));
-
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-
-        /* 방 퇴장 테스트 */
-        for (int i = 1; i <= threadCount; i++) {
-            User user = createUser(i);
-            executorService.submit(
-                    () -> {
-                        try {
-                            UserPrincipal principal =
-                                    new UserPrincipal(user, Collections.emptyMap());
-                            SecurityUtils.setAuthentication(user);
-                            log.info("room.getHost().getId() = {}", room.getHost().getId());
-                            roomService.exitRoom(roomId, principal);
-                        } catch (Exception e) {
-
-                        } finally {
-                            SecurityContextHolder.clearContext();
-                            countDownLatch.countDown();
-                        }
-                    });
-        }
-        countDownLatch.await();
-        verify(roomRepository).removeRoom(roomId);
     }
 
-    private Room createRoom(
-            Long roomId,
-            Long playerId,
-            Long quizId,
-            String password,
-            int maxUserCount,
-            boolean locked) {
-        RoomSetting roomSetting = new RoomSetting("방제목", maxUserCount, locked, password);
-        GameSetting gameSetting = new GameSetting(quizId, 10, 60);
-        Player host = new Player(playerId, "nickname");
+    @Test
+    @DisplayName("동일 유저가 여러 탭에서 동시 초기화 요청 시 데드락 없이 처리되고, 최종적으로 하나의 방에만 존재 (가장 마지막에 시도한 방)")
+    void initializeRoomSocket_concurrently_sameUser_noDeadlockAndConsistency() throws InterruptedException {
+        // Given
+        Long roomId1 = 1L;
+        Long roomId2 = 2L;
+        Long testUserId = 1000L; // 테스트 대상 유저 ID
+        String nickname = "TestUser";
+        int maxUserCount = 4;
 
-        return new Room(roomId, roomSetting, gameSetting, host);
-    }
 
-    private User createUser(int i) {
-        Long userId = i + 1L;
-        String provider = "provider +" + i;
-        String providerId = "providerId" + i;
-        LocalDateTime lastLogin = LocalDateTime.now();
+        UserPrincipal userPrincipal = createUserPrincipal(testUserId);
 
-        User user =
-                User.builder()
-                        .provider(provider)
-                        .providerId(providerId)
-                        .lastLogin(lastLogin)
-                        .build();
+        // 방 1 생성
+        Room room1 = createAndSaveRoom(roomId1, 2000L, "Host1", maxUserCount);
 
-        try {
-            Field idField = User.class.getDeclaredField("id");
-            idField.setAccessible(true);
-            idField.set(user, userId);
-        } catch (Exception e) {
-            throw new RuntimeException("ID 설정 실패", e);
+        // 방 2 생성
+        Room room2 = createAndSaveRoom(roomId2, 3000L, "Host2", maxUserCount);
+
+        Player testPlayer = createPlayer(testUserId, nickname);
+        roomRepository.findRoom(roomId1).orElseThrow().addPlayer(testPlayer);
+        userRoomRepository.addUser(testPlayer, room1);
+
+        int numAttempts = 5; // 각 방에 대한 동시 초기화 요청 횟수
+        // 총 스레드 수는 numAttempts * 2 (room1에 대한 numAttempts, room2에 대한 numAttempts)
+        ExecutorService executorService = Executors.newFixedThreadPool(numAttempts * 2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(numAttempts * 2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        // 가장 마지막에 성공적으로 초기화된 방의 ID를 추적
+        List<AbstractMap.SimpleEntry<Long, Long>> successfulInitAttempts = Collections.synchronizedList(new ArrayList<>());
+
+
+        // When
+        for (int i = 0; i < numAttempts; i++) {
+            // Room1 초기화 시도
+            executorService.submit(() -> {
+               setSecurityContext(userPrincipal);
+                try {
+                    startLatch.await();
+                    long callTimestamp = System.nanoTime(); // 호출 시작 시간 기록
+                    roomService.initializeRoomSocket(roomId1, userPrincipal);
+                    successCount.incrementAndGet();
+                    successfulInitAttempts.add(new AbstractMap.SimpleEntry<>(roomId1, callTimestamp));
+                } catch (Exception e) {
+                    log.error("Room1 init failed for user {} in room {}: {}", userPrincipal.getUserId(), roomId1, e.getMessage(), e);
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
+
+            // Room2 초기화 시도
+            executorService.submit(() -> {
+                setSecurityContext(userPrincipal);
+                try {
+                    startLatch.await();
+                    long callTimestamp = System.nanoTime(); // 호출 시작 시간 기록
+                    roomService.initializeRoomSocket(roomId2, userPrincipal);
+                    successCount.incrementAndGet();
+                    successfulInitAttempts.add(new AbstractMap.SimpleEntry<>(roomId2, callTimestamp));
+                } catch (Exception e) {
+                    log.error("Room2 init failed for user {} in room {}: {}", userPrincipal.getUserId(), roomId2, e.getMessage(), e);
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
         }
 
-        return user;
+        startLatch.countDown();
+        assertThat(finishLatch.await(50, TimeUnit.SECONDS)).isTrue(); // 시간 충분히 늘림
+        executorService.shutdown();
+        assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+
+        // Then
+        // 최종적으로 유저는 하나의 방에만 존재해야 함
+        assertThat(userRoomRepository.isUserInAnyRoom(testUserId)).isTrue();
+        Long finalRoomId = userRoomRepository.getRoomId(testUserId);
+        assertThat(finalRoomId).isNotNull();
+
+        // 마지막으로 성공적으로 initializeRoomSocket이 호출된 방을 찾음
+        successfulInitAttempts.sort(Comparator.comparing(AbstractMap.SimpleEntry::getValue));
+        Long expectedFinalRoomId = null;
+        if (!successfulInitAttempts.isEmpty()) {
+            expectedFinalRoomId = successfulInitAttempts.get(successfulInitAttempts.size() - 1).getKey();
+        }
+
+        // 최종적으로 저장된 방 ID가 가장 마지막에 성공적으로 시도된 방 ID와 일치하는지 검증
+        assertThat(finalRoomId)
+            .as("Final room must be the one from the last successful initialization attempt")
+            .isEqualTo(expectedFinalRoomId);
+
+        // 각 방의 상태 검증
+        Room finalRoom1 = roomRepository.findRoom(roomId1).orElse(null);
+        Room finalRoom2 = roomRepository.findRoom(roomId2).orElse(null);
+
+        // 마지막 방에만 유저가 남아있는지 확인
+        if (finalRoomId.equals(roomId1)) {
+            assertThat(finalRoom1).isNotNull();
+            assertThat(finalRoom1.hasPlayer(testUserId)).isTrue();
+            // 다른 방에는 유저가 없어야 함
+            assertThat(finalRoom2 == null || !finalRoom2.hasPlayer(testUserId)).isTrue();
+            // 룸 카운트도 갱신되었는지 확인 (호스트 + 최종 유저)
+            assertThat(finalRoom1.getCurrentUserCnt()).isEqualTo(2); // 호스트1 + 테스트유저1
+        } else if (finalRoomId.equals(roomId2)) {
+            assertThat(finalRoom2).isNotNull();
+            assertThat(finalRoom2.hasPlayer(testUserId)).isTrue();
+            // 다른 방에는 유저가 없어야 함
+            assertThat(finalRoom1 == null || !finalRoom1.hasPlayer(testUserId)).isTrue();
+            // 룸 카운트도 갱신되었는지 확인 (호스트 + 최종 유저)
+            assertThat(finalRoom2.getCurrentUserCnt()).isEqualTo(2); // 호스트1 + 테스트유저1
+        } else {
+            // 이 경우는 발생해서는 안 됨 (userId가 두 방 중 하나에만 있어야 하므로)
+            assertThat(false).as("User must be in either room1 or room2").isTrue();
+        }
     }
+
+
+    @Test
+    @DisplayName("다수의 사용자가 동시 입장/나가기 시도 시 데드락 없이 정합성 유지")
+    void enterAndExit_concurrently_noDeadlockAndConsistency() throws InterruptedException {
+        // Given
+        Long roomId = 1L;
+        Long hostId = 100L;
+        int maxUserCount = 4;
+
+        // Room 생성 (호스트 포함 1명)
+        createAndSaveRoom(roomId, hostId, "Host", maxUserCount);
+
+        int numUsers = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(numUsers * 2); // 입장과 나가기 스레드
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(numUsers * 2);
+
+        // When
+        for (int i = 0; i < numUsers; i++) {
+            long userId = (long) i + 201;
+            UserPrincipal userPrincipal = createUserPrincipal(userId);
+            RoomValidationRequest enterRequest = new RoomValidationRequest(roomId, null);
+
+            // 입장 스레드
+            executorService.submit(() -> {
+                UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                context.setAuthentication(authentication);
+                SecurityContextHolder.setContext(context);
+                try {
+                    startLatch.await();
+                    roomService.enterRoom(enterRequest);
+                } catch (Exception e) {
+                    // 예상되는 예외: ROOM_USER_LIMIT_REACHED
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
+
+            // 나가기 스레드 (입장 시도 후 바로 나가기 시도)
+            executorService.submit(() -> {
+                setSecurityContext(userPrincipal);
+                try {
+                    startLatch.await();
+                    roomService.exitRoomWithLock(roomId, userPrincipal);
+                } catch (Exception e) {
+                    // 예상되는 예외: USER_NOT_FOUND (아직 입장하지 못했을 때)
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertThat(finishLatch.await(20, TimeUnit.SECONDS)).isTrue();
+        executorService.shutdown();
+        assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+
+        // Then
+        // 최종적으로 호스트만 남아있거나, 소수의 플레이어가 남아있을 수 있음
+        // 중요한 것은 데드락 없이 완료되고 시스템이 불안정한 상태가 되지 않는 것
+        Room finalRoom = roomRepository.findRoom(roomId).orElseThrow();
+        assertThat(finalRoom.hasPlayer(hostId)).isTrue(); // 호스트는 남아있어야 함
+        // 추가적인 플레이어의 수는 동시성 상황에 따라 유동적일 수 있음.
+        // 예를 들어, 어떤 유저가 입장 직후 바로 나가는 데 성공하면 0이 될 수도 있고,
+        // 어떤 유저가 입장만 성공하고 나가기는 실패할 수도 있음.
+        // 여기서는 데드락이 없고, 불필요한 예외가 발생하지 않으며, 최소한의 정합성(호스트 존재)만 확인.
+        System.out.println("Final user count in room " + roomId + ": " + finalRoom.getCurrentUserCnt());
+    }
+
+
+    @Test
+    @DisplayName("연결 끊긴 플레이어 처리 로직과 사용자 직접 나가기 로직 동시 호출 시 데드락 없음")
+    void disconnectAndExit_concurrently_noDeadlock() throws InterruptedException {
+        // Given
+        Long roomId = 1L;
+        Long hostId = 100L;
+        Long disconnectedUserId = 200L;
+        Long exitingUserId = 300L;
+
+        // 방 생성 및 플레이어 추가
+        int maxUserCount = 4;
+
+        // Room 생성
+        // 방 생성 및 플레이어 추가 - 헬퍼 메서드 사용
+        Room room = createAndSaveRoom(roomId, hostId, "Host", maxUserCount);
+        Player disconnectedPlayer = createPlayer(disconnectedUserId, "DisconnectedUser"); // 헬퍼 메서드 사용
+        Player exitingPlayer = createPlayer(exitingUserId, "ExitingUser"); // 헬퍼 메서드 사용
+
+        room.addPlayer(disconnectedPlayer);
+        room.addPlayer(exitingPlayer);
+
+        // UserRoomRepository 매핑
+        userRoomRepository.addUser(disconnectedPlayer, room);
+        userRoomRepository.addUser(exitingPlayer, room);
+
+        // disconnectOrExitRoom 호출 시 changeConnectedStatus를 간접적으로 테스트하기 위해 Mock 설정
+        // 이 부분은 room.updatePlayerConnectionState를 직접 호출하므로 Mocking 불필요.
+        // userRoomRepository.removeUser는 In-memory 구현체를 사용하므로 Mocking 불필요.
+
+        int numConcurrentCalls = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(numConcurrentCalls * 2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(numConcurrentCalls * 2);
+
+        // When
+        for (int i = 0; i < numConcurrentCalls; i++) {
+            long userId = (long) i + 201;
+            UserPrincipal disconnectedUserPrincipal = createUserPrincipal(disconnectedUserId);
+            // disconnectOrExitRoom (플레이어 연결 끊김 시뮬레이션)
+            executorService.submit(() -> {
+                setSecurityContext(disconnectedUserPrincipal);
+                try {
+                    startLatch.await();
+                    roomService.disconnectOrExitRoom(roomId, disconnectedUserPrincipal);
+                } catch (Exception e) {
+                    System.err.println("Disconnect error: " + e.getMessage());
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
+
+            UserPrincipal exitingUserPrincipal = createUserPrincipal(exitingUserId);
+
+            // exitRoomWithLock (사용자 직접 나가기 시뮬레이션)
+            executorService.submit(() -> {
+               setSecurityContext(exitingUserPrincipal);
+                try {
+                    startLatch.await();
+                    roomService.exitRoomWithLock(roomId, exitingUserPrincipal);
+                } catch (Exception e) {
+                    System.err.println("Exit error: " + e.getMessage());
+                } finally {
+                    SecurityContextHolder.clearContext();
+                    finishLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertThat(finishLatch.await(20, TimeUnit.SECONDS)).isTrue();
+        executorService.shutdown();
+        assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+
+        // Then
+        Room finalRoom = roomRepository.findRoom(roomId).orElseThrow();
+        assertThat(finalRoom.hasPlayer(hostId)).isTrue(); // 호스트는 남아있어야 함
+
+        // disconnectedUser와 exitingUser는 최종적으로 방에서 나가져야 함
+        assertThat(finalRoom.hasPlayer(disconnectedUserId)).isFalse();
+        assertThat(finalRoom.hasPlayer(exitingUserId)).isFalse();
+
+        assertThat(userRoomRepository.isUserInAnyRoom(disconnectedUserId)).isFalse();
+        assertThat(userRoomRepository.isUserInAnyRoom(exitingUserId)).isFalse();
+        assertThat(userRoomRepository.isUserInAnyRoom(hostId)).isTrue(); // 호스트는 남아있어야 함
+
+        // 최종 방 인원수 확인 (호스트 1명만 남아야 함)
+        assertThat(finalRoom.getCurrentUserCnt()).isEqualTo(1);
+    }
+
+
+    private Player createPlayer(Long userId, String nickname) {
+        return new Player(userId, nickname);
+    }
+
+
+    private UserPrincipal createUserPrincipal(Long userId) {
+        User user = new User("kakao", "providerId_" + userId, LocalDateTime.now());
+        ReflectionTestUtils.setField(user, "id", userId);
+        return new UserPrincipal(user, Collections.emptyMap());
+    }
+
+
+    private Room createAndSaveRoom(Long roomId, Long hostId, String hostNickname, int maxUserCount) {
+        RoomSetting roomSetting = new RoomSetting("testRoom", maxUserCount, false, null);
+        Player host = createPlayer(hostId, hostNickname);
+        Room room = new Room(roomId, roomSetting, new GameSetting(1L, 10, 3), host);
+        room.addPlayer(host);
+        roomRepository.saveRoom(room);
+        userRoomRepository.addUser(host, room);
+        return room;
+    }
+
+    private void setSecurityContext(UserPrincipal userPrincipal) {
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+
+    // --- 인메모리 저장소 구현체 (테스트용) ---
+
+    // RoomRepository의 인메모리 구현체
+    private static class InMemoryRoomRepository implements RoomRepository {
+        private final Map<Long, Room> rooms = new ConcurrentHashMap<>();
+
+        @Override
+        public void saveRoom(Room room) {
+            rooms.put(room.getId(), room);
+        }
+
+        @Override
+        public Optional<Room> findRoom(Long roomId) {
+            return Optional.ofNullable(rooms.get(roomId));
+        }
+
+        @Override
+        public List<Room> findAll() {
+            return rooms.values().stream().toList();
+        }
+
+        @Override
+        public void removeRoom(Long roomId) {
+            rooms.remove(roomId);
+        }
+    }
+
 }

--- a/backend/src/test/java/io/f1/backend/global/lock/LockExecutorTest.java
+++ b/backend/src/test/java/io/f1/backend/global/lock/LockExecutorTest.java
@@ -11,8 +11,7 @@ import static org.mockito.Mockito.when;
 
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.CommonErrorCode;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,23 +21,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 @ExtendWith(MockitoExtension.class)
 class LockExecutorTest {
 
-    @Mock
-    private RedissonClient redissonClient;
+    @Mock private RedissonClient redissonClient;
 
-    @Mock
-    private RLock rlock;
+    @Mock private RLock rlock;
 
-    @InjectMocks
-    private LockExecutor lockExecutor;
+    @InjectMocks private LockExecutor lockExecutor;
 
     private final String TEST_PREFIX = "room";
     private final Long TEST_ROOM_ID = 1L;
     private final long WAIT_TIME = 5L;
     private final long LEASE_TIME = 3L;
-    private final String EXPECTED_LOCK_KEY = "lock:"+TEST_PREFIX+":{"+TEST_ROOM_ID+"}";
+    private final String EXPECTED_LOCK_KEY = "lock:" + TEST_PREFIX + ":{" + TEST_ROOM_ID + "}";
     private final String EXPECTED_RETURN_VALUE = "success";
 
     @Test
@@ -51,7 +50,9 @@ class LockExecutorTest {
         when(rlock.isHeldByCurrentThread()).thenReturn(true);
 
         // when
-        String result = lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> EXPECTED_RETURN_VALUE);
+        String result =
+                lockExecutor.executeWithLock(
+                        TEST_PREFIX, TEST_ROOM_ID, () -> EXPECTED_RETURN_VALUE);
 
         // then
         assertEquals(EXPECTED_RETURN_VALUE, result);
@@ -68,8 +69,12 @@ class LockExecutorTest {
         when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(false);
 
         // when & then
-        CustomException ex = assertThrows(CustomException.class,
-            () -> lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> "SHOULD_NOT_RUN"));
+        CustomException ex =
+                assertThrows(
+                        CustomException.class,
+                        () ->
+                                lockExecutor.executeWithLock(
+                                        TEST_PREFIX, TEST_ROOM_ID, () -> "SHOULD_NOT_RUN"));
 
         assertEquals(CommonErrorCode.LOCK_ACQUISITION_FAILED, ex.getErrorCode());
         verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
@@ -85,8 +90,12 @@ class LockExecutorTest {
         when(rlock.tryLock(5L, 3L, TimeUnit.SECONDS)).thenThrow(new InterruptedException());
 
         // when & then
-        CustomException ex = assertThrows(CustomException.class,
-            () -> lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> "SHOULD_NOT_RUN"));
+        CustomException ex =
+                assertThrows(
+                        CustomException.class,
+                        () ->
+                                lockExecutor.executeWithLock(
+                                        TEST_PREFIX, TEST_ROOM_ID, () -> "SHOULD_NOT_RUN"));
 
         verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
         verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
@@ -141,10 +150,17 @@ class LockExecutorTest {
         when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(false);
 
         // when & then
-        CustomException ex = assertThrows(CustomException.class,
-            () -> lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> {
-                throw new IllegalStateException("Should not be executed");
-            }));
+        CustomException ex =
+                assertThrows(
+                        CustomException.class,
+                        () ->
+                                lockExecutor.executeWithLock(
+                                        TEST_PREFIX,
+                                        TEST_ROOM_ID,
+                                        () -> {
+                                            throw new IllegalStateException(
+                                                    "Should not be executed");
+                                        }));
 
         verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
         verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
@@ -161,19 +177,21 @@ class LockExecutorTest {
         when(rlock.isHeldByCurrentThread()).thenReturn(true);
 
         // when & then
-        RuntimeException ex = assertThrows(RuntimeException.class, () ->
-            lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> {
-                throw new RuntimeException("exception");
-            })
-        );
+        RuntimeException ex =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                lockExecutor.executeWithLock(
+                                        TEST_PREFIX,
+                                        TEST_ROOM_ID,
+                                        () -> {
+                                            throw new RuntimeException("exception");
+                                        }));
 
         assertEquals("exception", ex.getMessage());
-
 
         verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
         verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
         verify(rlock).unlock();
     }
-
-
 }

--- a/backend/src/test/java/io/f1/backend/global/lock/LockExecutorTest.java
+++ b/backend/src/test/java/io/f1/backend/global/lock/LockExecutorTest.java
@@ -1,0 +1,179 @@
+package io.f1.backend.global.lock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.CommonErrorCode;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+@ExtendWith(MockitoExtension.class)
+class LockExecutorTest {
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock rlock;
+
+    @InjectMocks
+    private LockExecutor lockExecutor;
+
+    private final String TEST_PREFIX = "room";
+    private final Long TEST_ROOM_ID = 1L;
+    private final long WAIT_TIME = 5L;
+    private final long LEASE_TIME = 3L;
+    private final String EXPECTED_LOCK_KEY = "lock:"+TEST_PREFIX+":{"+TEST_ROOM_ID+"}";
+    private final String EXPECTED_RETURN_VALUE = "success";
+
+    @Test
+    @DisplayName("락 획득 성공 시 supplier 로직이 실행되고 락 해제됨")
+    void executeWithLock_successfulLock_supplier() throws Exception {
+        // given
+
+        when(redissonClient.getLock(anyString())).thenReturn(rlock);
+        when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(true);
+        when(rlock.isHeldByCurrentThread()).thenReturn(true);
+
+        // when
+        String result = lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> EXPECTED_RETURN_VALUE);
+
+        // then
+        assertEquals(EXPECTED_RETURN_VALUE, result);
+        verify(redissonClient).getLock(EXPECTED_LOCK_KEY);
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock).unlock();
+    }
+
+    @Test
+    @DisplayName("락 획득 실패 시 CustomException(LOCK_ACQUISITION_FAILED)이 발생하는지 확인")
+    void executeWithLock_failToAcquireLock() throws Exception {
+
+        when(redissonClient.getLock(anyString())).thenReturn(rlock);
+        when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(false);
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class,
+            () -> lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> "SHOULD_NOT_RUN"));
+
+        assertEquals(CommonErrorCode.LOCK_ACQUISITION_FAILED, ex.getErrorCode());
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+        verify(rlock, never()).unlock();
+    }
+
+    @Test
+    @DisplayName("InterruptedException 발생 시 CustomException 발생 및 인터럽트 설정")
+    void executeWithLock_interruptedException() throws Exception {
+
+        when(redissonClient.getLock(anyString())).thenReturn(rlock);
+        when(rlock.tryLock(5L, 3L, TimeUnit.SECONDS)).thenThrow(new InterruptedException());
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class,
+            () -> lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> "SHOULD_NOT_RUN"));
+
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+        assertEquals(CommonErrorCode.LOCK_INTERRUPTED, ex.getErrorCode());
+        assertTrue(Thread.currentThread().isInterrupted());
+        verify(rlock, never()).unlock();
+    }
+
+    @Test
+    @DisplayName("Runnable 버전 executeWithLock 정상 동작")
+    void executeWithLock_runnableVersion() throws Exception {
+        // given
+        AtomicBoolean executed = new AtomicBoolean(false);
+
+        when(redissonClient.getLock(anyString())).thenReturn(rlock);
+        when(rlock.tryLock(5L, 3L, TimeUnit.SECONDS)).thenReturn(true);
+        when(rlock.isHeldByCurrentThread()).thenReturn(true);
+
+        // when
+        lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> executed.set(true));
+
+        // then
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+        assertTrue(executed.get());
+        verify(rlock).unlock();
+    }
+
+    @Test
+    @DisplayName("락을 획득했지만 현재 스레드가 소유하지 않은 경우 unlock 하지 않음")
+    void executeWithLock_notHeldByCurrentThread_shouldNotUnlock() throws Exception {
+        // given
+        when(redissonClient.getLock(EXPECTED_LOCK_KEY)).thenReturn(rlock);
+        when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(true);
+        when(rlock.isHeldByCurrentThread()).thenReturn(false);
+
+        // when
+        String result = lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> "EXECUTED");
+
+        // then
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+        assertEquals("EXECUTED", result);
+        verify(rlock, never()).unlock();
+    }
+
+    @Test
+    @DisplayName("락을 획득하지 않은 스레드가 unlock하지 않는지 확인")
+    void executeWithLock_lockNotAcquired_shouldNotUnlock() throws Exception {
+        // given
+        when(redissonClient.getLock(EXPECTED_LOCK_KEY)).thenReturn(rlock);
+        when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(false);
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class,
+            () -> lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> {
+                throw new IllegalStateException("Should not be executed");
+            }));
+
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+        assertEquals(CommonErrorCode.LOCK_ACQUISITION_FAILED, ex.getErrorCode());
+        verify(rlock, never()).unlock();
+    }
+
+    @Test
+    @DisplayName("메서드 실행 중 예외 발생 시에도 락이 정상적으로 해제되는지 확인")
+    void executeWithLock_exceptionThrown_shouldUnlock() throws Exception {
+        // given
+        when(redissonClient.getLock(EXPECTED_LOCK_KEY)).thenReturn(rlock);
+        when(rlock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)).thenReturn(true);
+        when(rlock.isHeldByCurrentThread()).thenReturn(true);
+
+        // when & then
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+            lockExecutor.executeWithLock(TEST_PREFIX, TEST_ROOM_ID, () -> {
+                throw new RuntimeException("exception");
+            })
+        );
+
+        assertEquals("exception", ex.getMessage());
+
+
+        verify(redissonClient, times(1)).getLock(EXPECTED_LOCK_KEY);
+        verify(rlock, times(1)).tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+        verify(rlock).unlock();
+    }
+
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #163 

## 🪐 작업 내용
- `AOP`로 적용할 수 없는 부분들이 있어서 수동 실행하는 `LockExecutor` 를 생성
- userId와 roomId 모두 락이 필요한 경우들에 있어서는 userId -> roomId 로 순서를 일관되게 유지
- 내부 호출이 얽혀있는 상황에서는 처음 호출할 때 락을 걸어서 진행 
<img width="1346" height="698" alt="image" src="https://github.com/user-attachments/assets/b4439499-01c7-403b-881a-e4f63561cbcd" />

- userId로 roomId를 가져오면 타이밍 이슈로 새로 입장하는 방 roomId를 가져와서 `disconencted` 처리 
- `sessionId` ,`roomId` 매핑되어있는 맵 생성하여 게임방 중복입장을 방지 (`handleDisconnectedListener` 이전방 `roomId`가져오기)


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?