### PR TITLE
[refactor] SSE 인원 입퇴장 이벤트 추가 및 SSE 사용 쿼리 분리

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -77,14 +77,15 @@ public class GameService {
         validateRoomStart(room, principal);
 
         Long quizId = room.getGameSetting().getQuizId();
-        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+        Quiz quiz = quizService.findQuizById(quizId);
+        Long questionsCount = quizService.getQuestionsCount(quizId);
         List<Question> questions = prepareQuestions(room, quiz);
 
         room.updateQuestions(questions);
         room.increaseCurrentRound();
         room.updateRoomState(RoomState.PLAYING);
 
-        eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz));
+        eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz, questionsCount));
 
         timerService.startTimer(room, START_DELAY);
 
@@ -210,7 +211,10 @@ public class GameService {
                 MessageType.GAME_SETTING,
                 toGameSettingResponse(
                         room.getGameSetting(),
-                        quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId())));
+                        quizService.findQuizById(room.getGameSetting().getQuizId()),
+                        room.getRound()
+                )
+        );
         messageSender.sendBroadcast(
                 destination, MessageType.ROOM_SETTING, toRoomSettingResponse(room));
     }
@@ -315,10 +319,11 @@ public class GameService {
 
     private void broadcastGameSetting(Room room) {
         String destination = getDestination(room.getId());
-        Quiz quiz = quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId());
+        Quiz quiz = quizService.findQuizById(room.getGameSetting().getQuizId());
+        Long questionsCount = quizService.getQuestionsCount(quiz.getId());
         messageSender.sendBroadcast(
                 destination,
                 MessageType.GAME_SETTING,
-                toGameSettingResponse(room.getGameSetting(), quiz));
+                toGameSettingResponse(room.getGameSetting(), quiz, questionsCount));
     }
 }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/GameService.java
@@ -212,9 +212,7 @@ public class GameService {
                 toGameSettingResponse(
                         room.getGameSetting(),
                         quizService.findQuizById(room.getGameSetting().getQuizId()),
-                        room.getRound()
-                )
-        );
+                        room.getRound()));
         messageSender.sendBroadcast(
                 destination, MessageType.ROOM_SETTING, toRoomSettingResponse(room));
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -29,6 +29,7 @@ import io.f1.backend.domain.game.dto.response.RoomSettingResponse;
 import io.f1.backend.domain.game.dto.response.SystemNoticeResponse;
 import io.f1.backend.domain.game.event.RoomCreatedEvent;
 import io.f1.backend.domain.game.event.RoomDeletedEvent;
+import io.f1.backend.domain.game.event.RoomUpdatedEvent;
 import io.f1.backend.domain.game.model.ConnectionState;
 import io.f1.backend.domain.game.model.GameSetting;
 import io.f1.backend.domain.game.model.Player;
@@ -229,6 +230,8 @@ public class RoomService {
                                         destination,
                                         MessageType.SYSTEM_NOTICE,
                                         systemNoticeResponse);
+
+                                eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz));
                             });
                 });
     }
@@ -470,6 +473,11 @@ public class RoomService {
 
         /* 플레이어 삭제 */
         room.removePlayer(player);
+
+        Long quizId = room.getQuizId();
+        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+
+        eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz));
     }
 
     public void handleDisconnectedPlayers(Room room, List<Player> disconnectedPlayers) {

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -205,7 +205,10 @@ public class RoomService {
                                 Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
                                 GameSettingResponse gameSettingResponse =
-                                        toGameSettingResponse(room.getGameSetting(), quiz, quiz.getQuestions().size());
+                                        toGameSettingResponse(
+                                                room.getGameSetting(),
+                                                quiz,
+                                                quiz.getQuestions().size());
 
                                 PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
@@ -231,7 +234,9 @@ public class RoomService {
                                         MessageType.SYSTEM_NOTICE,
                                         systemNoticeResponse);
 
-                                eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz, quiz.getQuestions().size()));
+                                eventPublisher.publishEvent(
+                                        new RoomUpdatedEvent(
+                                                room, quiz, quiz.getQuestions().size()));
                             });
                 });
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/app/RoomService.java
@@ -106,7 +106,7 @@ public class RoomService {
                 host.getId(),
                 () -> exitIfInAnotherRoom(room, getCurrentUserPrincipal()));
 
-        eventPublisher.publishEvent(new RoomCreatedEvent(room, quiz));
+        eventPublisher.publishEvent(new RoomCreatedEvent(room, quiz, gameSetting.getRound()));
 
         return new RoomCreateResponse(newId);
     }
@@ -205,7 +205,7 @@ public class RoomService {
                                 Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
 
                                 GameSettingResponse gameSettingResponse =
-                                        toGameSettingResponse(room.getGameSetting(), quiz);
+                                        toGameSettingResponse(room.getGameSetting(), quiz, quiz.getQuestions().size());
 
                                 PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
@@ -231,7 +231,7 @@ public class RoomService {
                                         MessageType.SYSTEM_NOTICE,
                                         systemNoticeResponse);
 
-                                eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz));
+                                eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz, quiz.getQuestions().size()));
                             });
                 });
     }
@@ -286,9 +286,9 @@ public class RoomService {
                         .map(
                                 room -> {
                                     Long quizId = room.getGameSetting().getQuizId();
-                                    Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
-
-                                    return toRoomResponse(room, quiz);
+                                    Quiz quiz = quizService.findQuizById(quizId);
+                                    Long questionsCount = quizService.getQuestionsCount(quizId);
+                                    return toRoomResponse(room, quiz, questionsCount);
                                 })
                         .toList();
         return new RoomListResponse(roomResponses);
@@ -332,10 +332,11 @@ public class RoomService {
 
             Long quizId = room.getGameSetting().getQuizId();
 
-            Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+            Quiz quiz = quizService.findQuizById(quizId);
+            Long questionsCount = quizService.getQuestionsCount(quizId);
 
             GameSettingResponse gameSettingResponse =
-                    toGameSettingResponse(room.getGameSetting(), quiz);
+                    toGameSettingResponse(room.getGameSetting(), quiz, questionsCount);
 
             PlayerListResponse playerListResponse = toPlayerListResponse(room);
 
@@ -475,9 +476,10 @@ public class RoomService {
         room.removePlayer(player);
 
         Long quizId = room.getQuizId();
-        Quiz quiz = quizService.getQuizWithQuestionsById(quizId);
+        Quiz quiz = quizService.findQuizById(quizId);
+        Long questionsCount = quizService.getQuestionsCount(quizId);
 
-        eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz));
+        eventPublisher.publishEvent(new RoomUpdatedEvent(room, quiz, questionsCount));
     }
 
     public void handleDisconnectedPlayers(Room room, List<Player> disconnectedPlayers) {

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
@@ -44,7 +44,9 @@ public record QuizChangeRequest(long quizId) implements GameSettingChanger {
         RoomUpdatedEvent roomUpdatedEvent =
                 new RoomUpdatedEvent(
                         room,
-                        quizService.getQuizWithQuestionsById(room.getGameSetting().getQuizId()));
+                        quizService.findQuizById(room.getGameSetting().getQuizId()),
+                        room.getGameSetting().getRound()
+                );
 
         eventPublisher.publishEvent(roomUpdatedEvent);
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/dto/request/QuizChangeRequest.java
@@ -45,8 +45,7 @@ public record QuizChangeRequest(long quizId) implements GameSettingChanger {
                 new RoomUpdatedEvent(
                         room,
                         quizService.findQuizById(room.getGameSetting().getQuizId()),
-                        room.getGameSetting().getRound()
-                );
+                        room.getGameSetting().getRound());
 
         eventPublisher.publishEvent(roomUpdatedEvent);
     }

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomCreatedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomCreatedEvent.java
@@ -3,4 +3,4 @@ package io.f1.backend.domain.game.event;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
-public record RoomCreatedEvent(Room room, Quiz quiz) {}
+public record RoomCreatedEvent(Room room, Quiz quiz, long questionSize) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/event/RoomUpdatedEvent.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/event/RoomUpdatedEvent.java
@@ -3,4 +3,4 @@ package io.f1.backend.domain.game.event;
 import io.f1.backend.domain.game.model.Room;
 import io.f1.backend.domain.quiz.entity.Quiz;
 
-public record RoomUpdatedEvent(Room room, Quiz quiz) {}
+public record RoomUpdatedEvent(Room room, Quiz quiz, long questionSize) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
@@ -51,9 +51,12 @@ public class RoomMapper {
                 room.getRoomSetting().locked());
     }
 
-    public static GameSettingResponse toGameSettingResponse(GameSetting gameSetting, Quiz quiz, long questionsCount) {
+    public static GameSettingResponse toGameSettingResponse(
+            GameSetting gameSetting, Quiz quiz, long questionsCount) {
         return new GameSettingResponse(
-                gameSetting.getRound(), gameSetting.getTimeLimit(), toQuizResponse(quiz, questionsCount));
+                gameSetting.getRound(),
+                gameSetting.getTimeLimit(),
+                toQuizResponse(quiz, questionsCount));
     }
 
     public static PlayerListResponse toPlayerListResponse(Room room) {

--- a/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/mapper/RoomMapper.java
@@ -51,9 +51,9 @@ public class RoomMapper {
                 room.getRoomSetting().locked());
     }
 
-    public static GameSettingResponse toGameSettingResponse(GameSetting gameSetting, Quiz quiz) {
+    public static GameSettingResponse toGameSettingResponse(GameSetting gameSetting, Quiz quiz, long questionsCount) {
         return new GameSettingResponse(
-                gameSetting.getRound(), gameSetting.getTimeLimit(), toQuizResponse(quiz));
+                gameSetting.getRound(), gameSetting.getTimeLimit(), toQuizResponse(quiz, questionsCount));
     }
 
     public static PlayerListResponse toPlayerListResponse(Room room) {
@@ -66,7 +66,7 @@ public class RoomMapper {
                 room.getHost().getNickname(), playerResponseList, playerResponseList.size());
     }
 
-    public static RoomResponse toRoomResponse(Room room, Quiz quiz) {
+    public static RoomResponse toRoomResponse(Room room, Quiz quiz, long questionsCount) {
         return new RoomResponse(
                 room.getId(),
                 room.getRoomSetting().roomName(),
@@ -77,17 +77,17 @@ public class RoomMapper {
                 quiz.getTitle(),
                 quiz.getDescription(),
                 quiz.getCreator().getNickname(),
-                quiz.getQuestions().size(),
+                (int) questionsCount,
                 quiz.getThumbnailUrl());
     }
 
-    public static QuizResponse toQuizResponse(Quiz quiz) {
+    public static QuizResponse toQuizResponse(Quiz quiz, long questionsCount) {
         return new QuizResponse(
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getDescription(),
                 quiz.getThumbnailUrl(),
-                quiz.getQuestions().size());
+                (int) questionsCount);
     }
 
     public static SystemNoticeResponse ofPlayerEvent(String nickname, RoomEventType roomEventType) {

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomCreatedPayload.java
@@ -10,5 +10,5 @@ public record RoomCreatedPayload(
         String quizTitle,
         String description,
         String creator,
-        int numberOfQuestion,
+        int numberOfQuestions,
         String thumbnailUrl) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomUpdatedPayload.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/dto/RoomUpdatedPayload.java
@@ -7,5 +7,5 @@ public record RoomUpdatedPayload(
         String quizTitle,
         String description,
         String creator,
-        int numberOfQuestion,
+        int numberOfQuestions,
         String thumbnailUrl) {}

--- a/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
+++ b/backend/src/main/java/io/f1/backend/domain/game/sse/mapper/SseMapper.java
@@ -16,6 +16,7 @@ public class SseMapper {
     public static LobbySseEvent<RoomCreatedPayload> fromRoomCreated(RoomCreatedEvent event) {
         Room room = event.room();
         Quiz quiz = event.quiz();
+        long questionSize = event.questionSize();
         RoomCreatedPayload payload =
                 new RoomCreatedPayload(
                         room.getId(),
@@ -27,7 +28,7 @@ public class SseMapper {
                         quiz.getTitle(),
                         quiz.getDescription(),
                         quiz.getCreator().getNickname(),
-                        quiz.getQuestions().size(),
+                        (int) questionSize,
                         quiz.getThumbnailUrl());
         return new LobbySseEvent<>(SseEventType.CREATE.name(), payload);
     }
@@ -35,6 +36,7 @@ public class SseMapper {
     public static LobbySseEvent<RoomUpdatedPayload> fromRoomUpdated(RoomUpdatedEvent event) {
         Room room = event.room();
         Quiz quiz = event.quiz();
+        long questionSize = event.questionSize();
         RoomUpdatedPayload payload =
                 new RoomUpdatedPayload(
                         room.getId(),
@@ -43,7 +45,7 @@ public class SseMapper {
                         quiz.getTitle(),
                         quiz.getDescription(),
                         quiz.getCreator().getNickname(),
-                        quiz.getQuestions().size(),
+                        (int) questionSize,
                         quiz.getThumbnailUrl());
         return new LobbySseEvent<>(SseEventType.UPDATE.name(), payload);
     }


### PR DESCRIPTION
## 🛰️ Issue Number
#180 

## 🪐 작업 내용
- 퇴장에 해당하는 cleanRoom, 입장에 해당하는 initializeRoomSocket 메서드에 SSE 이벤트 퍼블리셔를 추가했습니다.
- 퀴즈가 문제의 정보까지 fetch join하는 getQuizWithQuestionsById 쿼리에서 findQuizById 쿼리로 문제 테이블은 Lazy 로딩하도록 변경 및 퀴즈의 문제 개수만 세는 getQuestionsCount를 추가하여 쿼리 두 개로 변경

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?