### PR TITLE
docs: 최신 dev 커밋에 대한 도커 이미지 생성

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,47 @@
+name: release-dev
+on:
+  push:
+    branches:
+      - dev
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-image:
+    name: 도커 이미지 빌드
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Check out Repository
+        uses: actions/checkout@v4
+
+      - name: Sign in github container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=dev-latest
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 🛰️ Issue Number
- #182 

## 🪐 작업 내용
현재 dev->main으로의 수동 PR을 통해서만 도커 이미지를 생성할 수 있는 형태입니다.

이는 dev와 api에서의 테스트를 진행하려면 dev->main으로의 수동 PR을 필요로 하게 되는데,
이때 main에서도 자동으로 이미지를 업데이트하기 때문에, 파이프라인의 오류가 존재했던 것 같습니다.

따라서, 운영 환경은 latest 태그를 따라가는 현 상태를 유지하고, 개발 환경은 dev 최신 커밋에 대해 dev-latest 태그를 생성하도록 해 운영 환경과 개발 환경의 배포 파이프라인을 다르게 가져가고자 합니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?