### PR TITLE
[fix] release-dev workflow에서 dockerfile 위치를 못 읽는 문제 해결

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and Push Image
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ./backend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 🛰️ Issue Number
- #184 

## 🪐 작업 내용
release-dev workflow에서 dockerfile 위치를 못 읽는 문제가 발생했습니다.
이에 대해 context 위치를 dockerfile이 존재하는 backend로 설정해 문제를 해결했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?