### PR TITLE
[feat] 테스트를 위한 로그인 엔드포인트 추가

### DIFF
--- a/backend/src/main/java/io/f1/backend/domain/user/api/TestUserController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/TestUserController.java
@@ -1,0 +1,27 @@
+package io.f1.backend.domain.user.api;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.f1.backend.domain.user.app.TestUserService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Profile("!prod")
+@RequiredArgsConstructor
+@RequestMapping("/user/test")
+public class TestUserController {
+
+    private final TestUserService userService;
+
+    @PostMapping("/login/{userId}")
+    public ResponseEntity<Void> login(@PathVariable Long userId, HttpSession session) {
+        userService.login(userId, session);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/api/TestUserController.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/api/TestUserController.java
@@ -1,15 +1,17 @@
 package io.f1.backend.domain.user.api;
 
+import io.f1.backend.domain.user.app.TestUserService;
+
+import jakarta.servlet.http.HttpSession;
+
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.f1.backend.domain.user.app.TestUserService;
-import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @Profile("!prod")

--- a/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
@@ -2,29 +2,34 @@ package io.f1.backend.domain.user.app;
 
 import static io.f1.backend.domain.user.constants.SessionKeys.USER;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import io.f1.backend.domain.user.dao.UserRepository;
 import io.f1.backend.domain.user.dto.AuthenticationUser;
 import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
 import io.f1.backend.global.security.util.SecurityUtils;
+
 import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Profile("!prod")
 @RequiredArgsConstructor
 public class TestUserService {
-    
+
     private final UserRepository userRepository;
-    
+
     @Transactional(readOnly = true)
     public void login(Long userId, HttpSession session) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         session.setAttribute(USER, AuthenticationUser.from(user));
         SecurityUtils.setAuthentication(user);
     }

--- a/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
@@ -1,0 +1,31 @@
+package io.f1.backend.domain.user.app;
+
+import static io.f1.backend.domain.user.constants.SessionKeys.USER;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.f1.backend.domain.user.dao.UserRepository;
+import io.f1.backend.domain.user.dto.AuthenticationUser;
+import io.f1.backend.domain.user.entity.User;
+import io.f1.backend.global.exception.CustomException;
+import io.f1.backend.global.exception.errorcode.UserErrorCode;
+import io.f1.backend.global.security.util.SecurityUtils;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Profile("!prod")
+@RequiredArgsConstructor
+public class TestUserService {
+    
+    private final UserRepository userRepository;
+    
+    @Transactional(readOnly = true)
+    public void login(Long userId, HttpSession session) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        session.setAttribute(USER, AuthenticationUser.from(user));
+        SecurityUtils.setAuthentication(user);
+    }
+}

--- a/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
@@ -1,9 +1,7 @@
 package io.f1.backend.domain.user.app;
 
-import static io.f1.backend.domain.user.constants.SessionKeys.USER;
 
 import io.f1.backend.domain.user.dao.UserRepository;
-import io.f1.backend.domain.user.dto.AuthenticationUser;
 import io.f1.backend.domain.user.entity.User;
 import io.f1.backend.global.exception.CustomException;
 import io.f1.backend.global.exception.errorcode.UserErrorCode;
@@ -32,7 +30,7 @@ public class TestUserService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-        
+
         SecurityUtils.setAuthentication(user);
         SecurityContext context = SecurityContextHolder.getContext();
         session.setAttribute("SPRING_SECURITY_CONTEXT", context);

--- a/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
+++ b/backend/src/main/java/io/f1/backend/domain/user/app/TestUserService.java
@@ -14,6 +14,8 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +32,9 @@ public class TestUserService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-        session.setAttribute(USER, AuthenticationUser.from(user));
+        
         SecurityUtils.setAuthentication(user);
+        SecurityContext context = SecurityContextHolder.getContext();
+        session.setAttribute("SPRING_SECURITY_CONTEXT", context);
     }
 }

--- a/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/io/f1/backend/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                                                 "/css/**",
                                                 "/js/**",
                                                 "/admin/login",
+                                                "/user/test/**",
                                                 actuatorBasePath + "/**")
                                         .permitAll()
                                         .requestMatchers(HttpMethod.OPTIONS, "/**")

--- a/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
+++ b/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
@@ -1,6 +1,5 @@
 package io.f1.backend.domain.user;
 
-import static io.f1.backend.domain.user.constants.SessionKeys.USER;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.github.database.rider.core.api.dataset.DataSet;
 
-import io.f1.backend.domain.user.dto.AuthenticationUser;
 import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.template.BrowserTestTemplate;
 
@@ -37,7 +35,7 @@ public class TestUserBrowserTest extends BrowserTestTemplate {
 
         SecurityContext context = (SecurityContext) session.getAttribute("SPRING_SECURITY_CONTEXT");
         assertThat(context.getAuthentication().getPrincipal()).isInstanceOf(UserPrincipal.class);
-        
+
         UserPrincipal userPrincipal = (UserPrincipal) context.getAuthentication().getPrincipal();
         assertThat(userPrincipal.getUserId()).isEqualTo(1L);
         assertThat(userPrincipal.getUserNickname()).isEqualTo("USER1");

--- a/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
+++ b/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
@@ -1,18 +1,20 @@
 package io.f1.backend.domain.user;
 
 import static io.f1.backend.domain.user.constants.SessionKeys.USER;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+
+import io.f1.backend.domain.user.dto.AuthenticationUser;
+import io.f1.backend.global.template.BrowserTestTemplate;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.ResultActions;
-import com.github.database.rider.core.api.dataset.DataSet;
-
-import io.f1.backend.domain.user.dto.AuthenticationUser;
-import io.f1.backend.global.template.BrowserTestTemplate;
 
 public class TestUserBrowserTest extends BrowserTestTemplate {
 
@@ -22,7 +24,7 @@ public class TestUserBrowserTest extends BrowserTestTemplate {
     void testUserLogin() throws Exception {
         // given
         MockHttpSession session = new MockHttpSession();
-        
+
         // when
         ResultActions result = mockMvc.perform(post("/user/test/login/1").session(session));
 

--- a/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
+++ b/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
@@ -1,0 +1,38 @@
+package io.f1.backend.domain.user;
+
+import static io.f1.backend.domain.user.constants.SessionKeys.USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.ResultActions;
+import com.github.database.rider.core.api.dataset.DataSet;
+
+import io.f1.backend.domain.user.dto.AuthenticationUser;
+import io.f1.backend.global.template.BrowserTestTemplate;
+
+public class TestUserBrowserTest extends BrowserTestTemplate {
+
+    @Test
+    @DataSet("datasets/user.yml")
+    @DisplayName("테스트 유저가 로그인하면 세션에 유저 정보가 저장된다")
+    void testUserLogin() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+        
+        // when
+        ResultActions result = mockMvc.perform(post("/user/test/login/1").session(session));
+
+        // then
+        result.andExpect(status().isOk());
+        assertThat(session.getAttribute(USER)).isNotNull();
+
+        AuthenticationUser authenticationUser = (AuthenticationUser) session.getAttribute(USER);
+        assertThat(authenticationUser.userId()).isEqualTo(1L);
+        assertThat(authenticationUser.nickname()).isEqualTo("USER1");
+        assertThat(authenticationUser.providerId()).isEqualTo("kakao1");
+    }
+}

--- a/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
+++ b/backend/src/test/java/io/f1/backend/domain/user/TestUserBrowserTest.java
@@ -3,24 +3,27 @@ package io.f1.backend.domain.user;
 import static io.f1.backend.domain.user.constants.SessionKeys.USER;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 
 import io.f1.backend.domain.user.dto.AuthenticationUser;
+import io.f1.backend.domain.user.dto.UserPrincipal;
 import io.f1.backend.global.template.BrowserTestTemplate;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.test.web.servlet.ResultActions;
 
 public class TestUserBrowserTest extends BrowserTestTemplate {
 
     @Test
     @DataSet("datasets/user.yml")
-    @DisplayName("테스트 유저가 로그인하면 세션에 유저 정보가 저장된다")
+    @DisplayName("테스트 유저가 로그인하면 세션에 SecurityContext가 저장된다")
     void testUserLogin() throws Exception {
         // given
         MockHttpSession session = new MockHttpSession();
@@ -30,11 +33,30 @@ public class TestUserBrowserTest extends BrowserTestTemplate {
 
         // then
         result.andExpect(status().isOk());
-        assertThat(session.getAttribute(USER)).isNotNull();
+        assertThat(session.getAttribute("SPRING_SECURITY_CONTEXT")).isNotNull();
 
-        AuthenticationUser authenticationUser = (AuthenticationUser) session.getAttribute(USER);
-        assertThat(authenticationUser.userId()).isEqualTo(1L);
-        assertThat(authenticationUser.nickname()).isEqualTo("USER1");
-        assertThat(authenticationUser.providerId()).isEqualTo("kakao1");
+        SecurityContext context = (SecurityContext) session.getAttribute("SPRING_SECURITY_CONTEXT");
+        assertThat(context.getAuthentication().getPrincipal()).isInstanceOf(UserPrincipal.class);
+        
+        UserPrincipal userPrincipal = (UserPrincipal) context.getAuthentication().getPrincipal();
+        assertThat(userPrincipal.getUserId()).isEqualTo(1L);
+        assertThat(userPrincipal.getUserNickname()).isEqualTo("USER1");
+    }
+
+    @Test
+    @DataSet("datasets/stat/one-user-stat.yml")
+    @DisplayName("테스트 유저가 로그인하면 마이페이지에 접근이 가능하다")
+    void testUserLoginSecurityContext() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+
+        // when
+        ResultActions beforeLogin = mockMvc.perform(get("/user/me").session(session));
+        mockMvc.perform(post("/user/test/login/1").session(session));
+        ResultActions afterLogin = mockMvc.perform(get("/user/me").session(session));
+
+        // then
+        beforeLogin.andExpect(status().isUnauthorized());
+        afterLogin.andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #187 

## 🪐 작업 내용
prod를 제외한 환경에서 테스트를 위한 엔드포인트(`/user/test/login/{userId}`)를 추가하고자 합니다.

추가하고자 하는 목적은 아래와 같습니다.

1. 카카오 계정이 한 개일 경우 혼자서는 게임 플레이 테스트가 불가능한 문제가 있습니다.
2. K6 부하 테스트를 진행할 때, OAuth 로그인을 패싱하고 테스트용 로그인 엔드포인트를 사용하고자 합니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?